### PR TITLE
Cascade delete logs referencing deleted transaction

### DIFF
--- a/db/migrations/00028_create_header_sync_logs_table.sql
+++ b/db/migrations/00028_create_header_sync_logs_table.sql
@@ -9,7 +9,7 @@ CREATE TABLE header_sync_logs
     data         BYTEA,
     block_number BIGINT,
     block_hash   VARCHAR(66),
-    tx_hash      VARCHAR(66) REFERENCES header_sync_transactions (hash),
+    tx_hash      VARCHAR(66) REFERENCES header_sync_transactions (hash) ON DELETE CASCADE,
     tx_index     INTEGER,
     log_index    INTEGER,
     raw          JSONB,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -381,7 +381,7 @@ ALTER SEQUENCE public.header_sync_receipts_id_seq OWNED BY public.header_sync_re
 CREATE TABLE public.header_sync_transactions (
     id integer NOT NULL,
     header_id integer NOT NULL,
-    hash character varying(66),
+    hash character varying(66) NOT NULL,
     gas_limit numeric,
     gas_price numeric,
     input_data bytea,
@@ -1102,7 +1102,7 @@ ALTER TABLE ONLY public.header_sync_logs
 --
 
 ALTER TABLE ONLY public.header_sync_logs
-    ADD CONSTRAINT header_sync_logs_tx_hash_fkey FOREIGN KEY (tx_hash) REFERENCES public.header_sync_transactions(hash);
+    ADD CONSTRAINT header_sync_logs_tx_hash_fkey FOREIGN KEY (tx_hash) REFERENCES public.header_sync_transactions(hash) ON DELETE CASCADE;
 
 
 --


### PR DESCRIPTION
- Prevents constraint violation when db wiped in arbitrary order
  during tests