### PR TITLE
(VDB-1017) Retry log extraction on error

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -108,16 +108,8 @@ func compose() {
 		LogWithCommand.Fatalf("failed to prepare config: %s", configErr.Error())
 	}
 
-	// Generate code to build the plugin according to the config file
-	LogWithCommand.Info("generating plugin")
-	generator, constructorErr := plugin.NewGenerator(genConfig, databaseConfig)
-	if constructorErr != nil {
-		LogWithCommand.Fatalf("initializing plugin generator failed: %s", constructorErr.Error())
-	}
-	generateErr := generator.GenerateExporterPlugin()
-	if generateErr != nil {
-		LogWithCommand.Fatalf("generating plugin failed: %s", generateErr.Error())
-	}
+	composeTransformers()
+
 	// TODO: Embed versioning info in the .so files so we know which version of vulcanizedb to run them with
 	_, pluginPath, pathErr := genConfig.GetPluginPaths()
 	if pathErr != nil {
@@ -128,4 +120,17 @@ func compose() {
 
 func init() {
 	rootCmd.AddCommand(composeCmd)
+}
+
+func composeTransformers() {
+	// Generate code to build the plugin according to the config file
+	LogWithCommand.Info("generating plugin")
+	generator, constructorErr := plugin.NewGenerator(genConfig, databaseConfig)
+	if constructorErr != nil {
+		LogWithCommand.Fatalf("initializing plugin generator failed: %s", constructorErr.Error())
+	}
+	generateErr := generator.GenerateExporterPlugin()
+	if generateErr != nil {
+		LogWithCommand.Fatalf("generating plugin failed: %s", generateErr.Error())
+	}
 }

--- a/cmd/composeAndExecute.go
+++ b/cmd/composeAndExecute.go
@@ -117,4 +117,6 @@ func init() {
 	rootCmd.AddCommand(composeAndExecuteCmd)
 	composeAndExecuteCmd.Flags().BoolVarP(&recheckHeadersArg, "recheck-headers", "r", false, "whether to re-check headers for watched events")
 	composeAndExecuteCmd.Flags().DurationVarP(&queueRecheckInterval, "queue-recheck-interval", "q", 5*time.Minute, "interval duration for rechecking queued storage diffs (ex: 5m30s)")
+	composeAndExecuteCmd.Flags().DurationVarP(&retryInterval, "retry-interval", "i", 7*time.Second, "interval duration between retries on execution error")
+	composeAndExecuteCmd.Flags().IntVarP(&maxUnexpectedErrors, "max-unexpected-errs", "m", 5, "maximum number of unexpected errors to allow (with retries) before exiting")
 }

--- a/cmd/composeAndExecute.go
+++ b/cmd/composeAndExecute.go
@@ -168,7 +168,7 @@ func composeAndExecute() {
 	// Use WaitGroup to wait on both goroutines
 	var wg syn.WaitGroup
 	if len(ethEventInitializers) > 0 {
-		ew := watcher.NewEventWatcher(&db, blockChain)
+		ew := watcher.NewEventWatcher(&db, blockChain, maxConsecutiveUnexpectedErrs, retryInterval)
 		err := ew.AddTransformers(ethEventInitializers)
 		if err != nil {
 			LogWithCommand.Fatalf("failed to add event transformer initializers to watcher: %s", err.Error())

--- a/cmd/composeAndExecute.go
+++ b/cmd/composeAndExecute.go
@@ -17,18 +17,8 @@
 package cmd
 
 import (
-	"plugin"
-	syn "sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/statediff"
-	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
-	"github.com/makerdao/vulcanizedb/libraries/shared/streamer"
-	"github.com/makerdao/vulcanizedb/libraries/shared/watcher"
-	"github.com/makerdao/vulcanizedb/pkg/fs"
-	p2 "github.com/makerdao/vulcanizedb/pkg/plugin"
-	"github.com/makerdao/vulcanizedb/pkg/plugin/helpers"
-	"github.com/makerdao/vulcanizedb/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -119,94 +109,8 @@ func composeAndExecute() {
 		LogWithCommand.Fatalf("failed to prepare config: %s", configErr.Error())
 	}
 
-	// Generate code to build the plugin according to the config file
-	LogWithCommand.Info("generating plugin")
-	generator, constructorErr := p2.NewGenerator(genConfig, databaseConfig)
-	if constructorErr != nil {
-		LogWithCommand.Fatalf("failed to initialize generator: %s", constructorErr.Error())
-	}
-	generateErr := generator.GenerateExporterPlugin()
-	if generateErr != nil {
-		LogWithCommand.Fatalf("generating plugin failed: %s", generateErr.Error())
-	}
-
-	// Get the plugin path and load the plugin
-	_, pluginPath, pathErr := genConfig.GetPluginPaths()
-	if pathErr != nil {
-		LogWithCommand.Fatalf("failed to get plugin paths: %s", pathErr.Error())
-	}
-	if !genConfig.Save {
-		defer helpers.ClearFiles(pluginPath)
-	}
-	LogWithCommand.Info("linking plugin ", pluginPath)
-	plug, openErr := plugin.Open(pluginPath)
-	if openErr != nil {
-		LogWithCommand.Fatalf("linking plugin failed: %s", openErr.Error())
-	}
-
-	// Load the `Exporter` symbol from the plugin
-	LogWithCommand.Info("loading transformers from plugin")
-	symExporter, lookupErr := plug.Lookup("Exporter")
-	if lookupErr != nil {
-		LogWithCommand.Fatalf("loading Exporter symbol failed: %s", lookupErr.Error())
-	}
-
-	// Assert that the symbol is of type Exporter
-	exporter, ok := symExporter.(Exporter)
-	if !ok {
-		LogWithCommand.Fatal("plugged-in symbol not of type Exporter")
-	}
-
-	// Use the Exporters export method to load the EventTransformerInitializer, StorageTransformerInitializer, and ContractTransformerInitializer sets
-	ethEventInitializers, ethStorageInitializers, ethContractInitializers := exporter.Export()
-
-	// Setup bc and db objects
-	blockChain := getBlockChain()
-	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
-
-	// Execute over transformer sets returned by the exporter
-	// Use WaitGroup to wait on both goroutines
-	var wg syn.WaitGroup
-	if len(ethEventInitializers) > 0 {
-		ew := watcher.NewEventWatcher(&db, blockChain, maxConsecutiveUnexpectedErrs, retryInterval)
-		err := ew.AddTransformers(ethEventInitializers)
-		if err != nil {
-			LogWithCommand.Fatalf("failed to add event transformer initializers to watcher: %s", err.Error())
-		}
-		wg.Add(1)
-		go watchEthEvents(&ew, &wg)
-	}
-
-	if len(ethStorageInitializers) > 0 {
-		switch storageDiffsSource {
-		case "geth":
-			logrus.Debug("fetching storage diffs from geth pub sub")
-			rpcClient, _ := getClients()
-			stateDiffStreamer := streamer.NewStateDiffStreamer(rpcClient)
-			payloadChan := make(chan statediff.Payload)
-			storageFetcher := fetcher.NewGethRpcStorageFetcher(&stateDiffStreamer, payloadChan)
-			sw := watcher.NewStorageWatcher(storageFetcher, &db)
-			sw.AddTransformers(ethStorageInitializers)
-			wg.Add(1)
-			go watchEthStorage(&sw, &wg)
-		default:
-			logrus.Debug("fetching storage diffs from csv")
-			tailer := fs.FileTailer{Path: storageDiffsPath}
-			storageFetcher := fetcher.NewCsvTailStorageFetcher(tailer)
-			sw := watcher.NewStorageWatcher(storageFetcher, &db)
-			sw.AddTransformers(ethStorageInitializers)
-			wg.Add(1)
-			go watchEthStorage(&sw, &wg)
-		}
-	}
-
-	if len(ethContractInitializers) > 0 {
-		gw := watcher.NewContractWatcher(&db, blockChain)
-		gw.AddTransformers(ethContractInitializers)
-		wg.Add(1)
-		go watchEthContract(&gw, &wg)
-	}
-	wg.Wait()
+	composeTransformers()
+	executeTransformers()
 }
 
 func init() {

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -82,6 +82,8 @@ func init() {
 	rootCmd.AddCommand(executeCmd)
 	executeCmd.Flags().BoolVarP(&recheckHeadersArg, "recheck-headers", "r", false, "whether to re-check headers for watched events")
 	executeCmd.Flags().DurationVarP(&queueRecheckInterval, "queue-recheck-interval", "q", 5*time.Minute, "interval duration for rechecking queued storage diffs (ex: 5m30s)")
+	executeCmd.Flags().DurationVarP(&retryInterval, "retry-interval", "i", 7*time.Second, "interval duration between retries on execution error")
+	executeCmd.Flags().IntVarP(&maxUnexpectedErrors, "max-unexpected-errs", "m", 5, "maximum number of unexpected errors to allow (with retries) before exiting")
 }
 
 func executeTransformers() {
@@ -121,7 +123,7 @@ func executeTransformers() {
 	// Use WaitGroup to wait on both goroutines
 	var wg sync.WaitGroup
 	if len(ethEventInitializers) > 0 {
-		ew := watcher.NewEventWatcher(&db, blockChain, maxConsecutiveUnexpectedErrs, retryInterval)
+		ew := watcher.NewEventWatcher(&db, blockChain, maxUnexpectedErrors, retryInterval)
 		addErr := ew.AddTransformers(ethEventInitializers)
 		if addErr != nil {
 			LogWithCommand.Fatalf("failed to add event transformer initializers to watcher: %s", addErr.Error())

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -112,7 +112,7 @@ func execute() {
 	// Use WaitGroup to wait on both goroutines
 	var wg syn.WaitGroup
 	if len(ethEventInitializers) > 0 {
-		ew := watcher.NewEventWatcher(&db, blockChain)
+		ew := watcher.NewEventWatcher(&db, blockChain, maxConsecutiveUnexpectedErrs, retryInterval)
 		addErr := ew.AddTransformers(ethEventInitializers)
 		if addErr != nil {
 			LogWithCommand.Fatalf("failed to add event transformer initializers to watcher: %s", addErr.Error())

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"plugin"
-	syn "sync"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/statediff"
@@ -75,7 +75,16 @@ func execute() {
 	if configErr != nil {
 		LogWithCommand.Fatalf("failed to prepare config: %s", configErr.Error())
 	}
+	executeTransformers()
+}
 
+func init() {
+	rootCmd.AddCommand(executeCmd)
+	executeCmd.Flags().BoolVarP(&recheckHeadersArg, "recheck-headers", "r", false, "whether to re-check headers for watched events")
+	executeCmd.Flags().DurationVarP(&queueRecheckInterval, "queue-recheck-interval", "q", 5*time.Minute, "interval duration for rechecking queued storage diffs (ex: 5m30s)")
+}
+
+func executeTransformers() {
 	// Get the plugin path and load the plugin
 	_, pluginPath, pathErr := genConfig.GetPluginPaths()
 	if pathErr != nil {
@@ -110,7 +119,7 @@ func execute() {
 
 	// Execute over transformer sets returned by the exporter
 	// Use WaitGroup to wait on both goroutines
-	var wg syn.WaitGroup
+	var wg sync.WaitGroup
 	if len(ethEventInitializers) > 0 {
 		ew := watcher.NewEventWatcher(&db, blockChain, maxConsecutiveUnexpectedErrs, retryInterval)
 		addErr := ew.AddTransformers(ethEventInitializers)
@@ -153,17 +162,11 @@ func execute() {
 	wg.Wait()
 }
 
-func init() {
-	rootCmd.AddCommand(executeCmd)
-	executeCmd.Flags().BoolVarP(&recheckHeadersArg, "recheck-headers", "r", false, "whether to re-check headers for watched events")
-	executeCmd.Flags().DurationVarP(&queueRecheckInterval, "queue-recheck-interval", "q", 5*time.Minute, "interval duration for rechecking queued storage diffs (ex: 5m30s)")
-}
-
 type Exporter interface {
 	Export() ([]transformer.EventTransformerInitializer, []transformer.StorageTransformerInitializer, []transformer.ContractTransformerInitializer)
 }
 
-func watchEthEvents(w *watcher.EventWatcher, wg *syn.WaitGroup) {
+func watchEthEvents(w *watcher.EventWatcher, wg *sync.WaitGroup) {
 	defer wg.Done()
 	// Execute over the EventTransformerInitializer set using the watcher
 	LogWithCommand.Info("executing event transformers")
@@ -179,7 +182,7 @@ func watchEthEvents(w *watcher.EventWatcher, wg *syn.WaitGroup) {
 	}
 }
 
-func watchEthStorage(w watcher.IStorageWatcher, wg *syn.WaitGroup) {
+func watchEthStorage(w watcher.IStorageWatcher, wg *sync.WaitGroup) {
 	defer wg.Done()
 	// Execute over the StorageTransformerInitializer set using the storage watcher
 	LogWithCommand.Info("executing storage transformers")
@@ -191,7 +194,7 @@ func watchEthStorage(w watcher.IStorageWatcher, wg *syn.WaitGroup) {
 	}
 }
 
-func watchEthContract(w *watcher.ContractWatcher, wg *syn.WaitGroup) {
+func watchEthContract(w *watcher.ContractWatcher, wg *sync.WaitGroup) {
 	defer wg.Done()
 	// Execute over the ContractTransformerInitializer set using the contract watcher
 	LogWithCommand.Info("executing contract_watcher transformers")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,8 +50,10 @@ var (
 )
 
 const (
-	pollingInterval  = 7 * time.Second
-	validationWindow = 15
+	pollingInterval              = 7 * time.Second
+	validationWindow             = 15
+	maxConsecutiveUnexpectedErrs = 5
+	retryInterval                = 7 * time.Second
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,24 +36,24 @@ import (
 )
 
 var (
+	LogWithCommand       logrus.Entry
+	SubCommand           string
 	cfgFile              string
 	databaseConfig       config.Database
 	genConfig            config.Plugin
 	ipc                  string
+	maxUnexpectedErrors  int
 	queueRecheckInterval time.Duration
+	recheckHeadersArg    bool
+	retryInterval        time.Duration
 	startingBlockNumber  int64
 	storageDiffsPath     string
-	recheckHeadersArg    bool
-	SubCommand           string
-	LogWithCommand       logrus.Entry
 	storageDiffsSource   string
 )
 
 const (
-	pollingInterval              = 7 * time.Second
-	validationWindow             = 15
-	maxConsecutiveUnexpectedErrs = 5
-	retryInterval                = 7 * time.Second
+	pollingInterval  = 7 * time.Second
+	validationWindow = 15
 )
 
 var rootCmd = &cobra.Command{

--- a/libraries/shared/mocks/log_delegator.go
+++ b/libraries/shared/mocks/log_delegator.go
@@ -17,6 +17,7 @@
 package mocks
 
 import (
+	"github.com/makerdao/vulcanizedb/libraries/shared/logs"
 	"github.com/makerdao/vulcanizedb/libraries/shared/transformer"
 )
 
@@ -41,5 +42,6 @@ func (delegator *MockLogDelegator) DelegateLogs() error {
 		delegator.DelegateErrors = []error{}
 		return thisErr
 	}
-	return nil
+	// return no logs error so that delegator hits retry interval when extractor under test
+	return logs.ErrNoLogs
 }

--- a/libraries/shared/mocks/log_extractor.go
+++ b/libraries/shared/mocks/log_extractor.go
@@ -18,6 +18,7 @@ package mocks
 
 import (
 	"github.com/makerdao/vulcanizedb/libraries/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/logs"
 	"github.com/makerdao/vulcanizedb/libraries/shared/transformer"
 )
 
@@ -44,5 +45,6 @@ func (extractor *MockLogExtractor) ExtractLogs(recheckHeaders constants.Transfor
 		extractor.ExtractLogsErrors = []error{}
 		return thisErr
 	}
-	return nil
+	// return no unchecked headers error so that extractor hits retry interval when delegator under test
+	return logs.ErrNoUncheckedHeaders
 }

--- a/libraries/shared/watcher/event_watcher_test.go
+++ b/libraries/shared/watcher/event_watcher_test.go
@@ -87,139 +87,99 @@ var _ = Describe("Event Watcher", func() {
 	})
 
 	Describe("Execute", func() {
-		BeforeEach(func() {
-			// Needs to be reset otherwise modifications to this val in individual
-			// tests leak out to pollute others
-			eventWatcher.MaxConsecutiveUnexpectedErrs = 0
-		})
-
-		It("extracts watched logs", func(done Done) {
-			delegator.DelegateErrors = []error{logs.ErrNoLogs}
+		It("extracts watched logs", func() {
 			extractor.ExtractLogsErrors = []error{nil, errExecuteClosed}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(errExecuteClosed))
-			Eventually(func() bool {
-				return extractor.ExtractLogsCount > 0
-			}).Should(BeTrue())
-			close(done)
+			Expect(extractor.ExtractLogsCount > 0).To(BeTrue())
 		})
 
-		It("returns error if extracting logs fails", func(done Done) {
-			delegator.DelegateErrors = []error{logs.ErrNoLogs}
+		It("returns error if extracting logs fails", func() {
 			extractor.ExtractLogsErrors = []error{fakes.FakeError}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(fakes.FakeError))
-			close(done)
 		})
 
-		It("retries on error if watcher configured with greater than zero maximum consecutive errors", func(done Done) {
+		It("retries on error if watcher configured with greater than zero maximum consecutive errors", func() {
 			eventWatcher.MaxConsecutiveUnexpectedErrs = 1
-			delegator.DelegateErrors = []error{logs.ErrNoLogs}
 			extractor.ExtractLogsErrors = []error{fakes.FakeError, errExecuteClosed}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(errExecuteClosed))
-			Eventually(func() bool {
-				return extractor.ExtractLogsCount > 0
-			}).Should(BeTrue())
-			close(done)
+			Expect(extractor.ExtractLogsCount > 0).To(BeTrue())
 		})
 
-		It("returns error if maximum consecutive errors exceeded", func(done Done) {
+		It("returns error if maximum consecutive errors exceeded", func() {
 			eventWatcher.MaxConsecutiveUnexpectedErrs = 1
-			delegator.DelegateErrors = []error{logs.ErrNoLogs}
 			extractor.ExtractLogsErrors = []error{fakes.FakeError, fakes.FakeError}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(fakes.FakeError))
-			close(done)
 		})
 
-		It("does not treat absence of unchecked logs as an unexpected error", func(done Done) {
-			delegator.DelegateErrors = []error{logs.ErrNoLogs}
+		It("does not treat absence of unchecked logs as an unexpected error", func() {
 			extractor.ExtractLogsErrors = []error{logs.ErrNoUncheckedHeaders, errExecuteClosed}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(errExecuteClosed))
-			Eventually(func() bool {
-				return extractor.ExtractLogsCount > 0
-			}).Should(BeTrue())
-			close(done)
 		})
 
-		It("extracts watched logs again if missing headers found", func(done Done) {
-			delegator.DelegateErrors = []error{logs.ErrNoLogs}
+		It("extracts watched logs again if missing headers found", func() {
 			extractor.ExtractLogsErrors = []error{nil, errExecuteClosed}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(errExecuteClosed))
-			Eventually(func() bool {
-				return extractor.ExtractLogsCount > 1
-			}).Should(BeTrue())
-			close(done)
+			Expect(extractor.ExtractLogsCount > 1).To(BeTrue())
 		})
 
-		It("returns error if extracting logs fails on subsequent run", func(done Done) {
-			delegator.DelegateErrors = []error{logs.ErrNoLogs}
+		It("returns error if extracting logs fails on subsequent run", func() {
 			extractor.ExtractLogsErrors = []error{nil, fakes.FakeError}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(fakes.FakeError))
-			close(done)
 		})
 
 		It("delegates untransformed logs", func() {
 			delegator.DelegateErrors = []error{nil, errExecuteClosed}
-			extractor.ExtractLogsErrors = []error{logs.ErrNoUncheckedHeaders}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(errExecuteClosed))
-			Eventually(func() bool {
-				return delegator.DelegateCallCount > 0
-			}).Should(BeTrue())
+			Expect(delegator.DelegateCallCount > 0).To(BeTrue())
 		})
 
-		It("returns error if delegating logs fails", func(done Done) {
+		It("returns error if delegating logs fails", func() {
 			delegator.DelegateErrors = []error{fakes.FakeError}
-			extractor.ExtractLogsErrors = []error{logs.ErrNoUncheckedHeaders}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(fakes.FakeError))
-			close(done)
 		})
 
-		It("delegates logs again if untransformed logs found", func(done Done) {
-			delegator.DelegateErrors = []error{nil, nil, nil, errExecuteClosed}
-			extractor.ExtractLogsErrors = []error{logs.ErrNoUncheckedHeaders}
+		It("delegates logs again if untransformed logs found", func() {
+			delegator.DelegateErrors = []error{nil, errExecuteClosed}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(errExecuteClosed))
-			Eventually(func() bool {
-				return delegator.DelegateCallCount > 1
-			}).Should(BeTrue())
-			close(done)
+			Expect(delegator.DelegateCallCount > 1).To(BeTrue())
 		})
 
-		It("returns error if delegating logs fails on subsequent run", func(done Done) {
+		It("returns error if delegating logs fails on subsequent run", func() {
 			delegator.DelegateErrors = []error{nil, fakes.FakeError}
-			extractor.ExtractLogsErrors = []error{logs.ErrNoUncheckedHeaders}
 
 			err := eventWatcher.Execute(constants.HeaderUnchecked)
 
 			Expect(err).To(MatchError(fakes.FakeError))
-			close(done)
 		})
 	})
 })


### PR DESCRIPTION
- With constant retry interval and max consecutive errors limit

Looking to get some early feedback on this. I think we could merge as is and resolve the issue that's the impetus for this story, but some ideas I'd consider adding include:
- applying the same retry logic to log delegation, and perhaps the storage watcher
- extracting a separate namespace for handling retries, if we do the above
- refactoring the `compose` and `execute` logic, so that we don't have to modify event watcher initialization in two places
- making the max consecutive errors and retry interval configurable from the cli
- refactoring the event watcher tests, attempting to obviate the need for a sentinel error (`errExecuteClosed`)

Hoping to make sure the fundamental approach seems sensible to folks before tossing in all of that :p