### PR TITLE
(VDB-1050) Add missing indexes in public schema

### DIFF
--- a/db/migrations/00014_create_receipts_table.sql
+++ b/db/migrations/00014_create_receipts_table.sql
@@ -11,6 +11,10 @@ CREATE TABLE full_sync_receipts
     tx_hash             VARCHAR(66)
 );
 
+CREATE INDEX full_sync_receipts_contract_address
+    ON full_sync_receipts (contract_address_id);
+
 
 -- +goose Down
+DROP INDEX full_sync_receipts_contract_address;
 DROP TABLE full_sync_receipts;

--- a/db/migrations/00016_add_receipts_fk_to_logs.sql
+++ b/db/migrations/00016_add_receipts_fk_to_logs.sql
@@ -8,8 +8,13 @@ ALTER TABLE full_sync_logs
             REFERENCES full_sync_receipts (id)
             ON DELETE CASCADE;
 
+CREATE INDEX full_sync_logs_receipt
+    ON full_sync_logs (receipt_id);
+
 
 -- +goose Down
+DROP INDEX full_sync_logs_receipt;
+
 ALTER TABLE full_sync_logs
     DROP CONSTRAINT receipts_fk;
 

--- a/db/migrations/00021_associate_receipts_with_blocks.sql
+++ b/db/migrations/00021_associate_receipts_with_blocks.sql
@@ -19,8 +19,13 @@ ON DELETE CASCADE;
 ALTER TABLE full_sync_receipts
   DROP COLUMN transaction_id;
 
+CREATE INDEX full_sync_receipts_block
+    ON full_sync_receipts (block_id);
+
 
 -- +goose Down
+DROP INDEX full_sync_receipts_block;
+
 ALTER TABLE full_sync_receipts
   ADD COLUMN transaction_id INT;
 

--- a/db/migrations/00022_create_headers_table.sql
+++ b/db/migrations/00022_create_headers_table.sql
@@ -13,6 +13,7 @@ CREATE TABLE public.headers
 
 -- Index is removed when table is
 CREATE INDEX headers_block_number ON public.headers (block_number);
+CREATE INDEX headers_eth_node ON public.headers (eth_node_id);
 
 
 -- +goose Down

--- a/db/migrations/00026_create_header_sync_transactions_table.sql
+++ b/db/migrations/00026_create_header_sync_transactions_table.sql
@@ -14,5 +14,9 @@ CREATE TABLE header_sync_transactions (
   "value"     NUMERIC
 );
 
+CREATE INDEX header_sync_transactions_header
+    ON header_sync_transactions (header_id);
+
 -- +goose Down
+DROP INDEX header_sync_transactions_header;
 DROP TABLE header_sync_transactions;

--- a/db/migrations/00027_create_header_sync_receipts_table.sql
+++ b/db/migrations/00027_create_header_sync_receipts_table.sql
@@ -14,6 +14,13 @@ CREATE TABLE header_sync_receipts
     UNIQUE (header_id, transaction_id)
 );
 
+CREATE INDEX header_sync_receipts_contract_address
+    ON header_sync_receipts (contract_address_id);
+CREATE INDEX header_sync_receipts_transaction
+    ON header_sync_receipts (transaction_id);
+
 
 -- +goose Down
+DROP INDEX header_sync_receipts_transaction;
+DROP INDEX header_sync_receipts_contract_address;
 DROP TABLE header_sync_receipts;

--- a/db/migrations/00028_create_uncles_table.sql
+++ b/db/migrations/00028_create_uncles_table.sql
@@ -11,5 +11,9 @@ CREATE TABLE public.uncles (
   UNIQUE (block_id, hash)
 );
 
+CREATE INDEX uncles_eth_node
+    ON uncles (eth_node_id);
+
 -- +goose Down
+DROP INDEX uncles_eth_node;
 DROP TABLE public.uncles;

--- a/db/migrations/00029_create_header_sync_logs_table.sql
+++ b/db/migrations/00029_create_header_sync_logs_table.sql
@@ -17,6 +17,13 @@ CREATE TABLE header_sync_logs
     UNIQUE (header_id, tx_index, log_index)
 );
 
+CREATE INDEX header_sync_logs_address
+    ON header_sync_logs (address);
+CREATE INDEX header_sync_logs_transaction
+    ON header_sync_logs (tx_hash);
+
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
+DROP INDEX header_sync_logs_transaction;
+DROP INDEX header_sync_logs_address;
 DROP TABLE header_sync_logs;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1067,10 +1067,73 @@ CREATE INDEX block_id_index ON public.full_sync_transactions USING btree (block_
 
 
 --
+-- Name: full_sync_logs_receipt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX full_sync_logs_receipt ON public.full_sync_logs USING btree (receipt_id);
+
+
+--
+-- Name: full_sync_receipts_block; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX full_sync_receipts_block ON public.full_sync_receipts USING btree (block_id);
+
+
+--
+-- Name: full_sync_receipts_contract_address; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX full_sync_receipts_contract_address ON public.full_sync_receipts USING btree (contract_address_id);
+
+
+--
+-- Name: header_sync_logs_address; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_logs_address ON public.header_sync_logs USING btree (address);
+
+
+--
+-- Name: header_sync_logs_transaction; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_logs_transaction ON public.header_sync_logs USING btree (tx_hash);
+
+
+--
+-- Name: header_sync_receipts_contract_address; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_receipts_contract_address ON public.header_sync_receipts USING btree (contract_address_id);
+
+
+--
+-- Name: header_sync_receipts_transaction; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_receipts_transaction ON public.header_sync_receipts USING btree (transaction_id);
+
+
+--
+-- Name: header_sync_transactions_header; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_transactions_header ON public.header_sync_transactions USING btree (header_id);
+
+
+--
 -- Name: headers_block_number; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX headers_block_number ON public.headers USING btree (block_number);
+
+
+--
+-- Name: headers_eth_node; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX headers_eth_node ON public.headers USING btree (eth_node_id);
 
 
 --
@@ -1099,6 +1162,13 @@ CREATE INDEX tx_from_index ON public.full_sync_transactions USING btree (tx_from
 --
 
 CREATE INDEX tx_to_index ON public.full_sync_transactions USING btree (tx_to);
+
+
+--
+-- Name: uncles_eth_node; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX uncles_eth_node ON public.uncles USING btree (eth_node_id);
 
 
 --


### PR DESCRIPTION
Add the indexes that postgraphile complains about lacking when run with the `--no-ignore-indexes` flag