### PR TITLE
Demote logging for storage watcher errors

### DIFF
--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -111,7 +111,7 @@ func (storageWatcher StorageWatcher) processRow(rawDiff storage.RawDiff) {
 	diffID, err := storageWatcher.StorageDiffRepository.CreateStorageDiff(rawDiff)
 	if err != nil {
 		if err == repositories.ErrDuplicateDiff {
-			logrus.Info("ignoring duplicate diff")
+			logrus.Trace("ignoring duplicate diff")
 			return
 		}
 		logrus.Warnf("failed to persist storage diff: %s", err.Error())
@@ -121,13 +121,13 @@ func (storageWatcher StorageWatcher) processRow(rawDiff storage.RawDiff) {
 
 	storageTransformer, isTransformerWatchingAddress := storageWatcher.getTransformer(persistedDiff)
 	if !isTransformerWatchingAddress {
-		logrus.Debug("ignoring diff from an unwatched contract")
+		logrus.Trace("ignoring diff from an unwatched contract")
 		return
 	}
 
 	headerID, err := storageWatcher.getHeaderID(persistedDiff)
 	if err != nil {
-		logrus.Infof("error getting header for diff: %s", err.Error())
+		logrus.Tracef("error getting header for diff: %s", err.Error())
 		storageWatcher.queueDiff(persistedDiff)
 		return
 	}
@@ -155,7 +155,7 @@ func (storageWatcher StorageWatcher) processQueue() {
 
 		headerID, getHeaderErr := storageWatcher.getHeaderID(diff)
 		if getHeaderErr != nil {
-			logrus.Infof("error getting header for diff: %s", getHeaderErr.Error())
+			logrus.Tracef("error getting header for diff: %s", getHeaderErr.Error())
 			continue
 		}
 		diff.HeaderID = headerID

--- a/pkg/datastore/postgres/repositories/header_repository.go
+++ b/pkg/datastore/postgres/repositories/header_repository.go
@@ -88,9 +88,6 @@ func (repository HeaderRepository) GetHeader(blockNumber int64) (core.Header, er
 	var header core.Header
 	err := repository.database.Get(&header, `SELECT id, block_number, hash, raw, block_timestamp FROM headers WHERE block_number = $1 AND eth_node_id = $2`,
 		blockNumber, repository.database.NodeID)
-	if err != nil {
-		logrus.Error("GetHeader: error getting headers: ", err)
-	}
 	return header, err
 }
 


### PR DESCRIPTION
- Info => Trace for common errors
- duplicate diffs will happen a lot on restart if re-reading the same
  file or transactions
- header will be frequently not found on startup since diff reading
  can significantly outpace headerSync