### PR TITLE
Return error from event_watcher.withRetry

### DIFF
--- a/libraries/shared/watcher/event_watcher.go
+++ b/libraries/shared/watcher/event_watcher.go
@@ -118,6 +118,7 @@ func (watcher *EventWatcher) withRetry(call func() error, expectedErr error, ope
 				logrus.Errorf("error %s logs: %s", operation, err.Error())
 				if consecutiveUnexpectedErrCount > watcher.MaxConsecutiveUnexpectedErrs {
 					errs <- err
+					return
 				}
 			}
 			time.Sleep(watcher.RetryInterval)


### PR DESCRIPTION
This seems to fix the error we were seeing [when testing the plugin.](https://github.com/makerdao/vdb-mcd-transformers/pull/70/checks?check_run_id=351531475)
