### PR TITLE
Add partial index for untransformed logs

### DIFF
--- a/db/migrations/00029_create_header_sync_logs_table.sql
+++ b/db/migrations/00029_create_header_sync_logs_table.sql
@@ -21,9 +21,13 @@ CREATE INDEX header_sync_logs_address
     ON header_sync_logs (address);
 CREATE INDEX header_sync_logs_transaction
     ON header_sync_logs (tx_hash);
+CREATE INDEX header_sync_logs_untransformed
+    ON header_sync_logs (transformed)
+    WHERE transformed is false;
 
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
 DROP INDEX header_sync_logs_transaction;
 DROP INDEX header_sync_logs_address;
+DROP INDEX header_sync_logs_untransformed;
 DROP TABLE header_sync_logs;


### PR DESCRIPTION
Should speed up our main DB offender by quite a bit, if the query planning gods are with us :crossed_fingers: 

```go
SELECT * FROM public.header_sync_logs WHERE transformed = false
```