### PR TITLE
Add index to public.headers (check_count)

### DIFF
--- a/db/migrations/00022_create_headers_table.sql
+++ b/db/migrations/00022_create_headers_table.sql
@@ -13,8 +13,13 @@ CREATE TABLE public.headers
 
 -- Index is removed when table is
 CREATE INDEX headers_block_number ON public.headers (block_number);
+CREATE INDEX headers_check_count ON public.headers (check_count);
 CREATE INDEX headers_eth_node ON public.headers (eth_node_id);
 
 
 -- +goose Down
+DROP INDEX headers_block_number;
+DROP INDEX headers_check_count;
+DROP INDEX headers_eth_node;
+
 DROP TABLE public.headers;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1130,6 +1130,13 @@ CREATE INDEX headers_block_number ON public.headers USING btree (block_number);
 
 
 --
+-- Name: headers_check_count; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX headers_check_count ON public.headers USING btree (check_count);
+
+
+--
 -- Name: headers_eth_node; Type: INDEX; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
- Since we frequently query for headers with a check_count less than n

Following in the same vein as Edvard's PR for public.header_sync_logs (transformed) - this is another one where the watcher is frequently querying for an ultimately small number of rows from a much larger table. Opted for a full, rather than partial, index since sometimes we query for check_count > 1, other times for check_count < 5, and could query for an arbitrary number depending on the configured max number of retries.