### PR TITLE
(VDB-1125) Enable exposing public schema in API

### DIFF
--- a/db/migrations/00001_create_nodes_table.sql
+++ b/db/migrations/00001_create_nodes_table.sql
@@ -9,5 +9,8 @@ CREATE TABLE eth_nodes
     UNIQUE (genesis_block, network_id, eth_node_id)
 );
 
+COMMENT ON TABLE public.eth_nodes
+    IS E'@omit';
+
 -- +goose Down
 DROP TABLE eth_nodes;

--- a/db/migrations/00004_create_checked_headers_table.sql
+++ b/db/migrations/00004_create_checked_headers_table.sql
@@ -5,5 +5,8 @@ CREATE TABLE public.checked_headers
     header_id INTEGER UNIQUE NOT NULL REFERENCES headers (id) ON DELETE CASCADE
 );
 
+COMMENT ON TABLE public.checked_headers
+    IS E'@omit';
+
 -- +goose Down
 DROP TABLE public.checked_headers;

--- a/db/migrations/00006_create_queued_storage_diffs_table.sql
+++ b/db/migrations/00006_create_queued_storage_diffs_table.sql
@@ -5,5 +5,8 @@ CREATE TABLE public.queued_storage
     diff_id BIGINT UNIQUE NOT NULL REFERENCES public.storage_diff (id)
 );
 
+COMMENT ON TABLE public.queued_storage
+    IS E'@omit';
+
 -- +goose Down
 DROP TABLE public.queued_storage;

--- a/db/migrations/00008_create_receipts_table.sql
+++ b/db/migrations/00008_create_receipts_table.sql
@@ -19,6 +19,8 @@ CREATE INDEX receipts_contract_address
 CREATE INDEX receipts_transaction
     ON public.receipts (transaction_id);
 
+COMMENT ON TABLE public.receipts
+    IS E'@omit';
 
 -- +goose Down
 DROP INDEX receipts_transaction;

--- a/db/migrations/00010_create_watched_logs_table.sql
+++ b/db/migrations/00010_create_watched_logs_table.sql
@@ -7,6 +7,9 @@ CREATE TABLE public.watched_logs
     topic_zero       VARCHAR(66)
 );
 
+COMMENT ON TABLE public.watched_logs
+    IS E'@omit';
+
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
 DROP TABLE public.watched_logs;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -62,6 +62,13 @@ CREATE TABLE public.checked_headers (
 
 
 --
+-- Name: TABLE checked_headers; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.checked_headers IS '@omit';
+
+
+--
 -- Name: checked_headers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -92,6 +99,13 @@ CREATE TABLE public.eth_nodes (
     network_id numeric,
     eth_node_id character varying(128)
 );
+
+
+--
+-- Name: TABLE eth_nodes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.eth_nodes IS '@omit';
 
 
 --
@@ -232,6 +246,13 @@ CREATE TABLE public.queued_storage (
 
 
 --
+-- Name: TABLE queued_storage; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.queued_storage IS '@omit';
+
+
+--
 -- Name: queued_storage_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -267,6 +288,13 @@ CREATE TABLE public.receipts (
     tx_hash character varying(66),
     rlp bytea
 );
+
+
+--
+-- Name: TABLE receipts; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.receipts IS '@omit';
 
 
 --
@@ -371,6 +399,13 @@ CREATE TABLE public.watched_logs (
     contract_address character varying(42),
     topic_zero character varying(66)
 );
+
+
+--
+-- Name: TABLE watched_logs; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.watched_logs IS '@omit';
 
 
 --


### PR DESCRIPTION
- Omit internal tables to reduce clutter

Opening this against the branch for #21 to minimize the diff. Can re-target toward staging and include additional `omit` comments for the rest of the public tables on `staging` if we don't want to proceed with removing full sync.