### PR TITLE
(VDB-1182) Add created and updated columns to header table

### DIFF
--- a/db/migrations/00003_create_headers_table.sql
+++ b/db/migrations/00003_create_headers_table.sql
@@ -8,8 +8,25 @@ CREATE TABLE public.headers
     block_timestamp NUMERIC,
     check_count     INTEGER     NOT NULL DEFAULT 0,
     eth_node_id     INTEGER     NOT NULL REFERENCES eth_nodes (id) ON DELETE CASCADE,
+    created         TIMESTAMP   NOT NULL DEFAULT NOW(),
+    updated         TIMESTAMP   NOT NULL DEFAULT NOW(),
     UNIQUE (block_number, hash, eth_node_id)
 );
+
+-- +goose StatementBegin
+CREATE FUNCTION set_header_updated() RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.updated = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER header_updated
+    BEFORE UPDATE ON public.headers
+    FOR EACH ROW
+EXECUTE PROCEDURE set_header_updated();
 
 -- Index is removed when table is
 CREATE INDEX headers_block_number ON public.headers (block_number);
@@ -21,5 +38,8 @@ CREATE INDEX headers_eth_node ON public.headers (eth_node_id);
 DROP INDEX headers_block_number;
 DROP INDEX headers_check_count;
 DROP INDEX headers_eth_node;
+
+DROP TRIGGER header_updated ON public.headers;
+DROP FUNCTION set_header_updated();
 
 DROP TABLE public.headers;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -16,6 +16,20 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+--
+-- Name: set_header_updated(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.set_header_updated() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    NEW.updated = NOW();
+    RETURN NEW;
+END;
+$$;
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -211,7 +225,9 @@ CREATE TABLE public.headers (
     raw jsonb,
     block_timestamp numeric,
     check_count integer DEFAULT 0 NOT NULL,
-    eth_node_id integer NOT NULL
+    eth_node_id integer NOT NULL,
+    created timestamp without time zone DEFAULT now() NOT NULL,
+    updated timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
@@ -667,6 +683,13 @@ CREATE INDEX receipts_transaction ON public.receipts USING btree (transaction_id
 --
 
 CREATE INDEX transactions_header ON public.transactions USING btree (header_id);
+
+
+--
+-- Name: headers header_updated; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER header_updated BEFORE UPDATE ON public.headers FOR EACH ROW EXECUTE FUNCTION public.set_header_updated();
 
 
 --

--- a/libraries/shared/repository/header_trigger_test.go
+++ b/libraries/shared/repository/header_trigger_test.go
@@ -1,0 +1,43 @@
+package repository_test
+
+import (
+	"math/rand"
+
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
+	"github.com/makerdao/vulcanizedb/pkg/fakes"
+	"github.com/makerdao/vulcanizedb/test_config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("header updated trigger", func() {
+	var db = test_config.NewTestDB(test_config.NewTestNode())
+
+	BeforeEach(func() {
+		test_config.CleanTestDB(db)
+	})
+
+	type dbHeader struct {
+		Created string
+		Updated string
+	}
+
+	It("updates time updated when record is changed", func() {
+		blockNumber := rand.Int63()
+		headerRepo := repositories.NewHeaderRepository(db)
+		header := fakes.GetFakeHeader(blockNumber)
+		headerID, insertErr := headerRepo.CreateOrUpdateHeader(header)
+		Expect(insertErr).NotTo(HaveOccurred())
+
+		var headerRes dbHeader
+		initialHeaderErr := db.Get(&headerRes, `SELECT created, updated FROM public.headers`)
+		Expect(initialHeaderErr).NotTo(HaveOccurred())
+		Expect(headerRes.Created).To(Equal(headerRes.Updated))
+
+		_, updateErr := db.Exec(`UPDATE public.headers SET hash = '{"new_hash"}' WHERE id = $1`, headerID)
+		Expect(updateErr).NotTo(HaveOccurred())
+		updatedHeaderErr := db.Get(&headerRes, `SELECT created, updated FROM public.headers`)
+		Expect(updatedHeaderErr).NotTo(HaveOccurred())
+		Expect(headerRes.Created).NotTo(Equal(headerRes.Updated))
+	})
+})


### PR DESCRIPTION
Some default values + a trigger to keep track of when a header is created + updated. Worth noting that the `updated` timestamp will change every time `UPDATE` is called for the record, even if the `UPDATE` didn't actually change anything. I think that should be ok for our purposes, but lmk if not :)