### PR TITLE
(VDB-1218) (VDB-1181) Enable syncing against multiple nodes

### DIFF
--- a/db/migrations/20200305202405_create_get_or_create_header_function.sql
+++ b/db/migrations/20200305202405_create_get_or_create_header_function.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- SQL in this section is executed when the migration is applied.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.get_or_create_header(block_number BIGINT, hash VARCHAR(66), raw JSONB, block_timestamp NUMERIC, eth_node_id INTEGER) RETURNS INTEGER AS
+$$
+DECLARE
+    matching_header_id INTEGER := (
+        SELECT id
+        FROM public.headers
+        WHERE headers.block_number = get_or_create_header.block_number
+        AND headers.hash = get_or_create_header.hash
+        );
+    nonmatching_header_id INTEGER := (
+        SELECT id
+        FROM public.headers
+        WHERE headers.block_number = get_or_create_header.block_number
+        AND headers.hash != get_or_create_header.hash
+        );
+    inserted_header_id INTEGER;
+BEGIN
+    IF matching_header_id != 0 THEN
+        RETURN matching_header_id;
+    END IF;
+
+    IF nonmatching_header_id != 0 THEN
+        DELETE FROM public.headers WHERE id = nonmatching_header_id;
+    end if;
+
+    INSERT INTO public.headers (hash, block_number, raw, block_timestamp, eth_node_id)
+        VALUES (get_or_create_header.hash, get_or_create_header.block_number, get_or_create_header.raw, get_or_create_header.block_timestamp, get_or_create_header.eth_node_id)
+        RETURNING id INTO inserted_header_id;
+
+    RETURN inserted_header_id;
+END
+    $$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+-- SQL in this section is executed when the migration is rolled back.
+DROP FUNCTION public.get_or_create_header(block_number BIGINT, hash VARCHAR, raw JSONB, block_timestamp NUMERIC, eth_node_id INTEGER);

--- a/db/migrations/20200305202405_create_get_or_create_header_function.sql
+++ b/db/migrations/20200305202405_create_get_or_create_header_function.sql
@@ -18,13 +18,21 @@ DECLARE
         WHERE headers.block_number = get_or_create_header.block_number
           AND headers.hash != get_or_create_header.hash
     );
+    max_block_number      BIGINT  := (
+        SELECT MAX(headers.block_number)
+        FROM public.headers
+    );
     inserted_header_id    INTEGER;
 BEGIN
     IF matching_header_id != 0 THEN
         RETURN matching_header_id;
     END IF;
 
-    IF nonmatching_header_id != 0 THEN
+    IF nonmatching_header_id != 0 AND block_number <= max_block_number - 15 THEN
+        RETURN nonmatching_header_id;
+    END IF;
+
+    IF nonmatching_header_id != 0 AND block_number > max_block_number - 15 THEN
         DELETE FROM public.headers WHERE id = nonmatching_header_id;
     END IF;
 

--- a/db/migrations/20200305202405_create_get_or_create_header_function.sql
+++ b/db/migrations/20200305202405_create_get_or_create_header_function.sql
@@ -2,22 +2,23 @@
 -- SQL in this section is executed when the migration is applied.
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION public.get_or_create_header(block_number BIGINT, hash VARCHAR(66), raw JSONB, block_timestamp NUMERIC, eth_node_id INTEGER) RETURNS INTEGER AS
+CREATE OR REPLACE FUNCTION public.get_or_create_header(block_number BIGINT, hash VARCHAR(66), raw JSONB,
+                                                       block_timestamp NUMERIC, eth_node_id INTEGER) RETURNS INTEGER AS
 $$
 DECLARE
-    matching_header_id INTEGER := (
+    matching_header_id    INTEGER := (
         SELECT id
         FROM public.headers
         WHERE headers.block_number = get_or_create_header.block_number
-        AND headers.hash = get_or_create_header.hash
-        );
+          AND headers.hash = get_or_create_header.hash
+    );
     nonmatching_header_id INTEGER := (
         SELECT id
         FROM public.headers
         WHERE headers.block_number = get_or_create_header.block_number
-        AND headers.hash != get_or_create_header.hash
-        );
-    inserted_header_id INTEGER;
+          AND headers.hash != get_or_create_header.hash
+    );
+    inserted_header_id    INTEGER;
 BEGIN
     IF matching_header_id != 0 THEN
         RETURN matching_header_id;
@@ -25,15 +26,16 @@ BEGIN
 
     IF nonmatching_header_id != 0 THEN
         DELETE FROM public.headers WHERE id = nonmatching_header_id;
-    end if;
+    END IF;
 
     INSERT INTO public.headers (hash, block_number, raw, block_timestamp, eth_node_id)
-        VALUES (get_or_create_header.hash, get_or_create_header.block_number, get_or_create_header.raw, get_or_create_header.block_timestamp, get_or_create_header.eth_node_id)
-        RETURNING id INTO inserted_header_id;
+    VALUES (get_or_create_header.hash, get_or_create_header.block_number, get_or_create_header.raw,
+            get_or_create_header.block_timestamp, get_or_create_header.eth_node_id)
+    RETURNING id INTO inserted_header_id;
 
     RETURN inserted_header_id;
 END
-    $$
+$$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -36,13 +36,21 @@ DECLARE
         WHERE headers.block_number = get_or_create_header.block_number
           AND headers.hash != get_or_create_header.hash
     );
+    max_block_number      BIGINT  := (
+        SELECT MAX(headers.block_number)
+        FROM public.headers
+    );
     inserted_header_id    INTEGER;
 BEGIN
     IF matching_header_id != 0 THEN
         RETURN matching_header_id;
     END IF;
 
-    IF nonmatching_header_id != 0 THEN
+    IF nonmatching_header_id != 0 AND block_number <= max_block_number - 15 THEN
+        RETURN nonmatching_header_id;
+    END IF;
+
+    IF nonmatching_header_id != 0 AND block_number > max_block_number - 15 THEN
         DELETE FROM public.headers WHERE id = nonmatching_header_id;
     END IF;
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -24,19 +24,19 @@ CREATE FUNCTION public.get_or_create_header(block_number bigint, hash character 
     LANGUAGE plpgsql
     AS $$
 DECLARE
-    matching_header_id INTEGER := (
+    matching_header_id    INTEGER := (
         SELECT id
         FROM public.headers
         WHERE headers.block_number = get_or_create_header.block_number
-        AND headers.hash = get_or_create_header.hash
-        );
+          AND headers.hash = get_or_create_header.hash
+    );
     nonmatching_header_id INTEGER := (
         SELECT id
         FROM public.headers
         WHERE headers.block_number = get_or_create_header.block_number
-        AND headers.hash != get_or_create_header.hash
-        );
-    inserted_header_id INTEGER;
+          AND headers.hash != get_or_create_header.hash
+    );
+    inserted_header_id    INTEGER;
 BEGIN
     IF matching_header_id != 0 THEN
         RETURN matching_header_id;
@@ -44,15 +44,16 @@ BEGIN
 
     IF nonmatching_header_id != 0 THEN
         DELETE FROM public.headers WHERE id = nonmatching_header_id;
-    end if;
+    END IF;
 
     INSERT INTO public.headers (hash, block_number, raw, block_timestamp, eth_node_id)
-        VALUES (get_or_create_header.hash, get_or_create_header.block_number, get_or_create_header.raw, get_or_create_header.block_timestamp, get_or_create_header.eth_node_id)
-        RETURNING id INTO inserted_header_id;
+    VALUES (get_or_create_header.hash, get_or_create_header.block_number, get_or_create_header.raw,
+            get_or_create_header.block_timestamp, get_or_create_header.eth_node_id)
+    RETURNING id INTO inserted_header_id;
 
     RETURN inserted_header_id;
 END
-    $$;
+$$;
 
 
 --

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -17,6 +17,45 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: get_or_create_header(bigint, character varying, jsonb, numeric, integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.get_or_create_header(block_number bigint, hash character varying, raw jsonb, block_timestamp numeric, eth_node_id integer) RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    matching_header_id INTEGER := (
+        SELECT id
+        FROM public.headers
+        WHERE headers.block_number = get_or_create_header.block_number
+        AND headers.hash = get_or_create_header.hash
+        );
+    nonmatching_header_id INTEGER := (
+        SELECT id
+        FROM public.headers
+        WHERE headers.block_number = get_or_create_header.block_number
+        AND headers.hash != get_or_create_header.hash
+        );
+    inserted_header_id INTEGER;
+BEGIN
+    IF matching_header_id != 0 THEN
+        RETURN matching_header_id;
+    END IF;
+
+    IF nonmatching_header_id != 0 THEN
+        DELETE FROM public.headers WHERE id = nonmatching_header_id;
+    end if;
+
+    INSERT INTO public.headers (hash, block_number, raw, block_timestamp, eth_node_id)
+        VALUES (get_or_create_header.hash, get_or_create_header.block_number, get_or_create_header.raw, get_or_create_header.block_timestamp, get_or_create_header.eth_node_id)
+        RETURNING id INTO inserted_header_id;
+
+    RETURN inserted_header_id;
+END
+    $$;
+
+
+--
 -- Name: set_header_updated(); Type: FUNCTION; Schema: public; Owner: -
 --
 

--- a/pkg/contract_watcher/repository/header_repository.go
+++ b/pkg/contract_watcher/repository/header_repository.go
@@ -171,18 +171,16 @@ func (r *headerRepository) MissingHeaders(startingBlockNumber, endingBlockNumber
 				LEFT JOIN checked_headers on headers.id = header_id
 				WHERE (header_id ISNULL OR checked_headers.` + id + `=0)
 				AND headers.block_number >= $1
-				AND headers.eth_node_id = $2
 				ORDER BY headers.block_number`
-		err = r.db.Select(&result, query, startingBlockNumber, r.db.NodeID)
+		err = r.db.Select(&result, query, startingBlockNumber)
 	} else {
 		query = `SELECT headers.id, headers.block_number, headers.hash FROM headers
 				LEFT JOIN checked_headers on headers.id = header_id
 				WHERE (header_id ISNULL OR checked_headers.` + id + `=0)
 				AND headers.block_number >= $1
 				AND headers.block_number <= $2
-				AND headers.eth_node_id = $3
 				ORDER BY headers.block_number`
-		err = r.db.Select(&result, query, startingBlockNumber, endingBlockNumber, r.db.NodeID)
+		err = r.db.Select(&result, query, startingBlockNumber, endingBlockNumber)
 	}
 	return continuousHeaders(result), err
 }
@@ -200,17 +198,15 @@ func (r *headerRepository) MissingHeadersForAll(startingBlockNumber, endingBlock
 	}
 	if endingBlockNumber == -1 {
 		endStr := `) AND headers.block_number >= $1
-				  AND headers.eth_node_id = $2
 				  ORDER BY headers.block_number`
 		query = baseQuery + endStr
-		err = r.db.Select(&result, query, startingBlockNumber, r.db.NodeID)
+		err = r.db.Select(&result, query, startingBlockNumber)
 	} else {
 		endStr := `) AND headers.block_number >= $1
 				  AND headers.block_number <= $2
-				  AND headers.eth_node_id = $3
 				  ORDER BY headers.block_number`
 		query = baseQuery + endStr
-		err = r.db.Select(&result, query, startingBlockNumber, endingBlockNumber, r.db.NodeID)
+		err = r.db.Select(&result, query, startingBlockNumber, endingBlockNumber)
 	}
 	return continuousHeaders(result), err
 }
@@ -233,17 +229,15 @@ func (r *headerRepository) MissingMethodsCheckedEventsIntersection(startingBlock
 	baseQuery = baseQuery[:len(baseQuery)-5] + `) `
 	if endingBlockNumber == -1 {
 		endStr := `AND headers.block_number >= $1
-				  AND headers.eth_node_id = $2
 				  ORDER BY headers.block_number`
 		query = baseQuery + endStr
-		err = r.db.Select(&result, query, startingBlockNumber, r.db.NodeID)
+		err = r.db.Select(&result, query, startingBlockNumber)
 	} else {
 		endStr := `AND headers.block_number >= $1
 				  AND headers.block_number <= $2
-				  AND headers.eth_node_id = $3
 				  ORDER BY headers.block_number`
 		query = baseQuery + endStr
-		err = r.db.Select(&result, query, startingBlockNumber, endingBlockNumber, r.db.NodeID)
+		err = r.db.Select(&result, query, startingBlockNumber, endingBlockNumber)
 	}
 	return continuousHeaders(result), err
 }

--- a/pkg/datastore/postgres/repositories/checked_headers_repository.go
+++ b/pkg/datastore/postgres/repositories/checked_headers_repository.go
@@ -64,25 +64,21 @@ func (repo CheckedHeadersRepository) UncheckedHeaders(startingBlockNumber, endin
 		query = `SELECT id, block_number, hash
 			FROM public.headers
 			WHERE (check_count < 1
-			           AND block_number >= $1
-			           AND eth_node_id = $3)
+			           AND block_number >= $1)
 			   OR (check_count < $2
-			           AND block_number <= ((SELECT MAX(block_number) FROM public.headers) - ($4 * check_count * (check_count + 1) / 2))
-			           AND eth_node_id = $3)`
-		err = repo.db.Select(&result, query, startingBlockNumber, checkCount, repo.db.NodeID, recheckOffsetMultiplier)
+			           AND block_number <= ((SELECT MAX(block_number) FROM public.headers) - ($3 * check_count * (check_count + 1) / 2)))`
+		err = repo.db.Select(&result, query, startingBlockNumber, checkCount, recheckOffsetMultiplier)
 	} else {
 		query = `SELECT id, block_number, hash
 			FROM public.headers
 			WHERE (check_count < 1
 			           AND block_number >= $1
-			           AND block_number <= $2
-			           AND eth_node_id = $4)
+			           AND block_number <= $2)
 			   OR (check_count < $3
 			           AND block_number >= $1
 			           AND block_number <= $2
-			           AND block_number <= ((SELECT MAX(block_number) FROM public.headers) - ($5 * (check_count * (check_count + 1) / 2)))
-			           AND eth_node_id = $4)`
-		err = repo.db.Select(&result, query, startingBlockNumber, endingBlockNumber, checkCount, repo.db.NodeID, recheckOffsetMultiplier)
+			           AND block_number <= ((SELECT MAX(block_number) FROM public.headers) - ($4 * (check_count * (check_count + 1) / 2))))`
+		err = repo.db.Select(&result, query, startingBlockNumber, endingBlockNumber, checkCount, recheckOffsetMultiplier)
 	}
 
 	return result, err

--- a/pkg/fakes/data.go
+++ b/pkg/fakes/data.go
@@ -50,7 +50,7 @@ func GetFakeHeader(blockNumber int64) core.Header {
 
 func GetFakeHeaderWithTimestamp(timestamp, blockNumber int64) core.Header {
 	return core.Header{
-		Hash:        FakeHash.String(),
+		Hash:        "0x" + RandomString(64),
 		BlockNumber: blockNumber,
 		Raw:         rawFakeHeader,
 		Timestamp:   strconv.FormatInt(timestamp, 10),


### PR DESCRIPTION
- check for existing header in SQL so that concurrent updates can't
  break break constraints
- also loosen requirements for matching node ID since multiple nodes
  can create headers for whole system