### PR TITLE
Add Uint32 type for medianizer storage

### DIFF
--- a/libraries/shared/storage/types/value.go
+++ b/libraries/shared/storage/types/value.go
@@ -22,6 +22,7 @@ type ValueType int
 
 const (
 	Uint256 ValueType = iota
+	Uint32
 	Uint48
 	Uint128
 	Bytes32


### PR DESCRIPTION
Additional type needed for [141](https://github.com/makerdao/vdb-mcd-transformers/pull/141)