### PR TITLE
Backfill updates

### DIFF
--- a/db/migrations/20200415113349_update_create_back_filled_diff_function.sql
+++ b/db/migrations/20200415113349_update_create_back_filled_diff_function.sql
@@ -1,0 +1,78 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.create_back_filled_diff(block_height BIGINT, block_hash BYTEA, hashed_address BYTEA,
+                                                          storage_key BYTEA, storage_value BYTEA) RETURNS VOID AS
+$$
+DECLARE
+    last_storage_value  BYTEA := (
+        SELECT storage_diff.storage_value
+        FROM public.storage_diff
+        WHERE storage_diff.block_height <= create_back_filled_diff.block_height
+          AND storage_diff.hashed_address = create_back_filled_diff.hashed_address
+          AND storage_diff.storage_key = create_back_filled_diff.storage_key
+        ORDER BY storage_diff.block_height DESC
+        LIMIT 1
+    );
+    empty_storage_value BYTEA := (
+        SELECT '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA
+    );
+BEGIN
+    IF last_storage_value = create_back_filled_diff.storage_value THEN
+        RETURN;
+    END IF;
+
+    IF last_storage_value is null and create_back_filled_diff.storage_value = empty_storage_value THEN
+        RETURN;
+    END IF;
+
+    INSERT INTO public.storage_diff (block_height, block_hash, hashed_address, storage_key, storage_value,
+                                     from_backfill)
+    VALUES (create_back_filled_diff.block_height, create_back_filled_diff.block_hash,
+            create_back_filled_diff.hashed_address, create_back_filled_diff.storage_key,
+            create_back_filled_diff.storage_value, true)
+    ON CONFLICT DO NOTHING;
+
+    RETURN;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.create_back_filled_diff(block_height BIGINT, block_hash BYTEA, hashed_address BYTEA,
+                                                          storage_key BYTEA, storage_value BYTEA) RETURNS VOID AS
+$$
+DECLARE
+    last_storage_value  BYTEA := (
+        SELECT storage_diff.storage_value
+        FROM public.storage_diff
+        WHERE storage_diff.hashed_address = create_back_filled_diff.hashed_address
+          AND storage_diff.storage_key = create_back_filled_diff.storage_key
+        ORDER BY storage_diff.block_height DESC
+        LIMIT 1
+    );
+    empty_storage_value BYTEA := (
+        SELECT '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA
+    );
+BEGIN
+    IF last_storage_value = create_back_filled_diff.storage_value THEN
+        RETURN;
+    END IF;
+
+    IF last_storage_value is null and create_back_filled_diff.storage_value = empty_storage_value THEN
+        RETURN;
+    END IF;
+
+    INSERT INTO public.storage_diff (block_height, block_hash, hashed_address, storage_key, storage_value,
+                                     from_backfill)
+    VALUES (create_back_filled_diff.block_height, create_back_filled_diff.block_hash,
+            create_back_filled_diff.hashed_address, create_back_filled_diff.storage_key,
+            create_back_filled_diff.storage_value, true)
+    ON CONFLICT DO NOTHING;
+
+    RETURN;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -27,7 +27,8 @@ DECLARE
     last_storage_value  BYTEA := (
         SELECT storage_diff.storage_value
         FROM public.storage_diff
-        WHERE storage_diff.hashed_address = create_back_filled_diff.hashed_address
+        WHERE storage_diff.block_height <= create_back_filled_diff.block_height
+          AND storage_diff.hashed_address = create_back_filled_diff.hashed_address
           AND storage_diff.storage_key = create_back_filled_diff.storage_key
         ORDER BY storage_diff.block_height DESC
         LIMIT 1
@@ -750,7 +751,7 @@ CREATE INDEX receipts_transaction ON public.receipts USING btree (transaction_id
 -- Name: storage_diff_checked_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX storage_diff_checked_index ON public.storage_diff USING btree (checked);
+CREATE INDEX storage_diff_checked_index ON public.storage_diff USING btree (checked) WHERE (checked IS FALSE);
 
 
 --

--- a/libraries/shared/factories/storage/keys_lookup.go
+++ b/libraries/shared/factories/storage/keys_lookup.go
@@ -67,9 +67,12 @@ func (lookup *keysLookup) Lookup(key common.Hash) (types.ValueMetadata, error) {
 }
 
 func (lookup *keysLookup) refreshMappings() error {
-	var err error
-	lookup.mappings, err = lookup.loader.LoadMappings()
-	return err
+	newMappings, err := lookup.loader.LoadMappings()
+	if err != nil {
+		return err
+	}
+	lookup.mappings = newMappings
+	return nil
 }
 
 func (lookup *keysLookup) SetDB(db *postgres.DB) {

--- a/libraries/shared/factories/storage/keys_lookup.go
+++ b/libraries/shared/factories/storage/keys_lookup.go
@@ -57,6 +57,7 @@ func (lookup *keysLookup) Lookup(key common.Hash) (types.ValueMetadata, error) {
 		if refreshErr != nil {
 			return metadata, refreshErr
 		}
+		lookup.mappings = storage.AddHashedKeys(lookup.mappings)
 		metadata, ok = lookup.mappings[key]
 		if !ok {
 			return metadata, types.ErrKeyNotFound{Key: key.Hex()}
@@ -68,11 +69,7 @@ func (lookup *keysLookup) Lookup(key common.Hash) (types.ValueMetadata, error) {
 func (lookup *keysLookup) refreshMappings() error {
 	var err error
 	lookup.mappings, err = lookup.loader.LoadMappings()
-	if err != nil {
-		return err
-	}
-	lookup.mappings = storage.AddHashedKeys(lookup.mappings)
-	return nil
+	return err
 }
 
 func (lookup *keysLookup) SetDB(db *postgres.DB) {

--- a/libraries/shared/storage/backfill/storage_value_loader.go
+++ b/libraries/shared/storage/backfill/storage_value_loader.go
@@ -100,7 +100,7 @@ func (r *StorageValueLoader) getAndPersistStorageValues(address common.Address, 
 				HashedAddress: keccakOfAddress,
 				BlockHash:     blockHash,
 				BlockHeight:   int(blockNumber),
-				StorageKey:    storageKey,
+				StorageKey:    crypto.Keccak256Hash(storageKey.Bytes()),
 				StorageValue:  storageValueHash,
 			}
 			createDiffErr := r.StorageDiffRepo.CreateBackFilledStorageValue(diff)

--- a/libraries/shared/storage/backfill/storage_value_loader.go
+++ b/libraries/shared/storage/backfill/storage_value_loader.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	maxRequestSize    = 400
+	MaxRequestSize    = 400
 	emptyStorageValue = common.BytesToHash([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
 )
 
@@ -127,9 +127,9 @@ func chunkKeys(keys []common.Hash) [][]common.Hash {
 }
 
 func getNumberOfChunks(keys []common.Hash) int {
-	return len(keys)/maxRequestSize + 1
+	return len(keys)/MaxRequestSize + 1
 }
 
 func getChunkIndex(index int) int {
-	return index / maxRequestSize
+	return index / MaxRequestSize
 }

--- a/libraries/shared/storage/backfill/storage_value_loader.go
+++ b/libraries/shared/storage/backfill/storage_value_loader.go
@@ -127,7 +127,11 @@ func chunkKeys(keys []common.Hash) [][]common.Hash {
 }
 
 func getNumberOfChunks(keys []common.Hash) int {
-	return len(keys)/MaxRequestSize + 1
+	keysLength := len(keys)
+	if keysLength%MaxRequestSize == 0 {
+		return keysLength / MaxRequestSize
+	}
+	return keysLength/MaxRequestSize + 1
 }
 
 func getChunkIndex(index int) int {

--- a/libraries/shared/storage/backfill/storage_value_loader.go
+++ b/libraries/shared/storage/backfill/storage_value_loader.go
@@ -1,7 +1,6 @@
 package backfill
 
 import (
-	"database/sql"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -111,9 +110,6 @@ func (r *StorageValueLoader) getAndPersistStorageValues(address common.Address, 
 			}
 			createDiffErr := r.StorageDiffRepo.CreateBackFilledStorageValue(diff)
 			if createDiffErr != nil {
-				if createDiffErr == sql.ErrNoRows {
-					return nil
-				}
 				return createDiffErr
 			}
 		}

--- a/libraries/shared/storage/backfill/storage_value_loader_test.go
+++ b/libraries/shared/storage/backfill/storage_value_loader_test.go
@@ -1,7 +1,6 @@
 package backfill_test
 
 import (
-	"database/sql"
 	"math/big"
 	"math/rand"
 	"strings"
@@ -214,12 +213,6 @@ var _ = Describe("StorageValueLoader", func() {
 		}
 
 		Expect(diffRepo.CreateBackFilledStorageValuePassedRawDiffs).To(ConsistOf(expectedDiffOne, expectedDiffTwo))
-	})
-
-	It("ignores sql.ErrNoRows error for duplicate diffs", func() {
-		diffRepo.CreateBackFilledStorageValueReturnError = sql.ErrNoRows
-		runnerErr := runner.Run()
-		Expect(runnerErr).NotTo(HaveOccurred())
 	})
 
 	It("returns an error if inserting a diff fails", func() {

--- a/libraries/shared/storage/backfill/storage_value_loader_test.go
+++ b/libraries/shared/storage/backfill/storage_value_loader_test.go
@@ -153,7 +153,18 @@ var _ = Describe("StorageValueLoader", func() {
 
 		Expect(bc.BatchGetStorageAtCalls).To(ContainElement(fakes.BatchGetStorageAtCall{BlockNumber: bigIntBlockOne, Account: addressTwo, Keys: manyKeys[0:backfill.MaxRequestSize]}))
 		Expect(bc.BatchGetStorageAtCalls).To(ContainElement(fakes.BatchGetStorageAtCall{BlockNumber: bigIntBlockOne, Account: addressTwo, Keys: manyKeys[backfill.MaxRequestSize:]}))
+	})
 
+	It("does not send request for empty chunk if keys length % max request size == 0", func() {
+		manyKeys := make([]common.Hash, backfill.MaxRequestSize)
+		for index, _ := range manyKeys {
+			manyKeys[index] = test_data.FakeHash()
+		}
+		keysLookupTwo.KeysToReturn = manyKeys
+
+		runnerErr := runner.Run()
+		Expect(runnerErr).NotTo(HaveOccurred())
+		Expect(bc.BatchGetStorageAtCalls).NotTo(ContainElement(fakes.BatchGetStorageAtCall{BlockNumber: bigIntBlockOne, Account: addressTwo, Keys: nil}))
 	})
 
 	It("gets storage values from every header in block range", func() {

--- a/libraries/shared/storage/backfill/storage_value_loader_test.go
+++ b/libraries/shared/storage/backfill/storage_value_loader_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/makerdao/vulcanizedb/libraries/shared/mocks"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/backfill"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
+	"github.com/makerdao/vulcanizedb/libraries/shared/test_data"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	. "github.com/onsi/ginkgo"
@@ -20,19 +21,19 @@ import (
 
 var _ = Describe("StorageValueLoader", func() {
 	var (
-		bc                             *fakes.MockBlockChain
-		keysLookupOne, keysLookupTwo   mocks.MockStorageKeysLookup
-		runner                         backfill.StorageValueLoader
-		initializerOne, initializerTwo storage.TransformerInitializer
-		initializers                   []storage.TransformerInitializer
-		keyOne, keyTwo                 common.Hash
-		valueOne, valueTwo             common.Hash
-		addressOne, addressTwo         common.Address
-		blockOne, blockTwo             int64
-		bigIntBlockOne, bigIntBlockTwo *big.Int
-		fakeHeader                     core.Header
-		headerRepo                     fakes.MockHeaderRepository
-		diffRepo                       mocks.MockStorageDiffRepository
+		bc                                               *fakes.MockBlockChain
+		keysLookupOne, keysLookupTwo, keysLookupThree    mocks.MockStorageKeysLookup
+		runner                                           backfill.StorageValueLoader
+		initializerOne, initializerTwo, initializerThree storage.TransformerInitializer
+		initializers                                     []storage.TransformerInitializer
+		keyOne, keyTwo, keyThree                         common.Hash
+		valueOne, valueTwo, valueThree                   common.Hash
+		addressOne, addressTwo, addressThree             common.Address
+		blockOne, blockTwo, blockThree                   int64
+		bigIntBlockOne, bigIntBlockTwo, bigIntBlockThree *big.Int
+		fakeHeader                                       core.Header
+		headerRepo                                       fakes.MockHeaderRepository
+		diffRepo                                         mocks.MockStorageDiffRepository
 	)
 
 	BeforeEach(func() {
@@ -42,20 +43,29 @@ var _ = Describe("StorageValueLoader", func() {
 		bigIntBlockOne = big.NewInt(blockOne)
 		blockTwo = blockOne + 1
 		bigIntBlockTwo = big.NewInt(blockTwo)
+		blockThree = blockTwo + 1
+		bigIntBlockThree = big.NewInt(blockThree)
 
 		keysLookupOne = mocks.MockStorageKeysLookup{}
-		keyOne = common.Hash{1, 2, 3}
-		addressOne = fakes.FakeAddress
+		keyOne = test_data.FakeHash()
+		addressOne = test_data.FakeAddress()
 		keysLookupOne.KeysToReturn = []common.Hash{keyOne}
-		valueOne = common.BytesToHash([]byte{7, 8, 9})
+		valueOne = test_data.FakeHash()
 		bc.SetStorageValuesToReturn(blockOne, addressOne, valueOne[:])
 
 		keysLookupTwo = mocks.MockStorageKeysLookup{}
-		keyTwo = common.Hash{4, 5, 6}
-		addressTwo = fakes.AnotherFakeAddress
+		keyTwo = test_data.FakeHash()
+		addressTwo = test_data.FakeAddress()
 		keysLookupTwo.KeysToReturn = []common.Hash{keyTwo}
-		valueTwo = common.BytesToHash([]byte{10, 11, 12})
+		valueTwo = test_data.FakeHash()
 		bc.SetStorageValuesToReturn(blockOne, addressTwo, valueTwo[:])
+
+		keysLookupThree = mocks.MockStorageKeysLookup{}
+		keyThree = test_data.FakeHash()
+		addressThree = test_data.FakeAddress()
+		keysLookupThree.KeysToReturn = []common.Hash{keyThree}
+		valueThree = common.BytesToHash([]byte{})
+		bc.SetStorageValuesToReturn(blockThree, addressThree, valueThree[:])
 
 		initializerOne = storage.Transformer{
 			Address:           addressOne,
@@ -69,8 +79,14 @@ var _ = Describe("StorageValueLoader", func() {
 			Repository:        &mocks.MockStorageRepository{},
 		}.NewTransformer
 
-		initializers = []storage.TransformerInitializer{initializerOne, initializerTwo}
-		runner = backfill.NewStorageValueLoader(bc, nil, initializers, blockOne, blockTwo)
+		initializerThree = storage.Transformer{
+			Address:           addressThree,
+			StorageKeysLookup: &keysLookupThree,
+			Repository:        &mocks.MockStorageRepository{},
+		}.NewTransformer
+
+		initializers = []storage.TransformerInitializer{initializerOne, initializerTwo, initializerThree}
+		runner = backfill.NewStorageValueLoader(bc, nil, initializers, blockOne, blockThree)
 
 		diffRepo = mocks.MockStorageDiffRepository{}
 		runner.StorageDiffRepo = &diffRepo
@@ -103,7 +119,7 @@ var _ = Describe("StorageValueLoader", func() {
 		runnerErr := runner.Run()
 		Expect(runnerErr).NotTo(HaveOccurred())
 		Expect(headerRepo.GetHeadersInRangeStartingBlock).To(Equal(blockOne))
-		Expect(headerRepo.GetHeadersInRangeEndingBlock).To(Equal(blockTwo))
+		Expect(headerRepo.GetHeadersInRangeEndingBlock).To(Equal(blockThree))
 	})
 
 	It("returns an error if a header for the given block cannot be retrieved", func() {
@@ -122,6 +138,7 @@ var _ = Describe("StorageValueLoader", func() {
 		Expect(bc.BatchGetStorageAtCalls).To(ConsistOf(
 			fakes.BatchGetStorageAtCall{BlockNumber: bigIntBlockOne, Account: addressOne, Keys: []common.Hash{keyOne}},
 			fakes.BatchGetStorageAtCall{BlockNumber: bigIntBlockOne, Account: addressTwo, Keys: []common.Hash{keyTwo}},
+			fakes.BatchGetStorageAtCall{BlockNumber: bigIntBlockOne, Account: addressThree, Keys: []common.Hash{keyThree}},
 		))
 	})
 
@@ -129,8 +146,8 @@ var _ = Describe("StorageValueLoader", func() {
 		headerRepo.AllHeaders = []core.Header{
 			{BlockNumber: blockOne},
 			{BlockNumber: blockTwo},
+			{BlockNumber: blockThree},
 		}
-		bc.SetStorageValuesToReturn(blockTwo, addressTwo, valueTwo[:])
 
 		runnerErr := runner.Run()
 		Expect(runnerErr).NotTo(HaveOccurred())
@@ -142,6 +159,9 @@ var _ = Describe("StorageValueLoader", func() {
 		))
 		Expect(bc.BatchGetStorageAtCalls).To(ContainElement(
 			fakes.BatchGetStorageAtCall{BlockNumber: bigIntBlockTwo, Account: addressTwo, Keys: []common.Hash{keyTwo}},
+		))
+		Expect(bc.BatchGetStorageAtCalls).To(ContainElement(
+			fakes.BatchGetStorageAtCall{BlockNumber: bigIntBlockThree, Account: addressThree, Keys: []common.Hash{keyThree}},
 		))
 	})
 
@@ -155,7 +175,7 @@ var _ = Describe("StorageValueLoader", func() {
 		Expect(runnerErr).To(Equal(fakes.FakeError))
 	})
 
-	It("persists the storage values for each transformer", func() {
+	It("persists the non-zero storage values for each transformer", func() {
 		runnerErr := runner.Run()
 		Expect(runnerErr).NotTo(HaveOccurred())
 

--- a/libraries/shared/storage/backfill/storage_value_loader_test.go
+++ b/libraries/shared/storage/backfill/storage_value_loader_test.go
@@ -185,14 +185,14 @@ var _ = Describe("StorageValueLoader", func() {
 			BlockHeight:   int(blockOne),
 			BlockHash:     headerHashBytes,
 			HashedAddress: crypto.Keccak256Hash(addressOne[:]),
-			StorageKey:    keyOne,
+			StorageKey:    crypto.Keccak256Hash(keyOne.Bytes()),
 			StorageValue:  valueOne,
 		}
 		expectedDiffTwo := types.RawDiff{
 			BlockHeight:   int(blockOne),
 			BlockHash:     headerHashBytes,
 			HashedAddress: crypto.Keccak256Hash(addressTwo[:]),
-			StorageKey:    keyTwo,
+			StorageKey:    crypto.Keccak256Hash(keyTwo.Bytes()),
 			StorageValue:  valueTwo,
 		}
 

--- a/libraries/shared/storage/diff_repository_test.go
+++ b/libraries/shared/storage/diff_repository_test.go
@@ -133,6 +133,21 @@ var _ = Describe("Storage diffs repository", func() {
 			Expect(count).To(Equal(1))
 		})
 
+		It("does duplicate storage value if same value only exists at a later block", func() {
+			_, createErr := repo.CreateStorageDiff(fakeStorageDiff)
+			Expect(createErr).NotTo(HaveOccurred())
+
+			duplicateDiff := fakeStorageDiff
+			duplicateDiff.BlockHeight = fakeStorageDiff.BlockHeight - 1
+			createTwoErr := repo.CreateBackFilledStorageValue(duplicateDiff)
+			Expect(createTwoErr).NotTo(HaveOccurred())
+
+			var count int
+			getErr := db.Get(&count, `SELECT count(*) FROM public.storage_diff`)
+			Expect(getErr).NotTo(HaveOccurred())
+			Expect(count).To(Equal(2))
+		})
+
 		It("inserts zero-valued storage if there's a previous diff", func() {
 			_, createOneErr := repo.CreateStorageDiff(fakeStorageDiff)
 			Expect(createOneErr).NotTo(HaveOccurred())

--- a/libraries/shared/test_data/generic.go
+++ b/libraries/shared/test_data/generic.go
@@ -31,7 +31,7 @@ var topic0 = "0x" + randomString(64)
 
 var GenericTestLog = func() types.Log {
 	return types.Log{
-		Address:     fakeAddress(),
+		Address:     FakeAddress(),
 		Topics:      []common.Hash{common.HexToHash(topic0), FakeHash()},
 		Data:        hexutil.MustDecode(FakeHash().Hex()),
 		BlockNumber: uint64(startingBlockNumber),
@@ -44,14 +44,14 @@ var GenericTestLog = func() types.Log {
 
 var GenericTestConfig = event.TransformerConfig{
 	TransformerName:     "generic-test-transformer",
-	ContractAddresses:   []string{fakeAddress().Hex()},
+	ContractAddresses:   []string{FakeAddress().Hex()},
 	ContractAbi:         randomString(100),
 	Topic:               topic0,
 	StartingBlockNumber: startingBlockNumber,
 	EndingBlockNumber:   startingBlockNumber + 1,
 }
 
-func fakeAddress() common.Address {
+func FakeAddress() common.Address {
 	return common.HexToAddress("0x" + randomString(40))
 }
 

--- a/pkg/fakes/mock_blockchain.go
+++ b/pkg/fakes/mock_blockchain.go
@@ -121,12 +121,12 @@ type BatchGetStorageAtCall struct {
 
 func (blockChain *MockBlockChain) BatchGetStorageAt(account common.Address, keys []common.Hash, blockNumber *big.Int) (map[common.Hash][]byte, error) {
 	var storageToReturn = make(map[common.Hash][]byte)
+	blockChain.BatchGetStorageAtCalls = append(blockChain.BatchGetStorageAtCalls, BatchGetStorageAtCall{
+		Account:     account,
+		Keys:        keys,
+		BlockNumber: blockNumber,
+	})
 	for _, key := range keys {
-		blockChain.BatchGetStorageAtCalls = append(blockChain.BatchGetStorageAtCalls, BatchGetStorageAtCall{
-			Account:     account,
-			Keys:        keys,
-			BlockNumber: blockNumber,
-		})
 		storageToReturn[key] = blockChain.storageValuesToReturn[account][blockNumber.Int64()]
 	}
 


### PR DESCRIPTION
- [X] Don't attempt to insert if storage value is 0
- [X] Don't lookup hashed key (only lookup by un-hashed key)
- [X] Hash key before inserting (to match inserts from current Geth patch)
- [X] Chunk up batch calls to avoid 413 response
- [X] Update `create_back_filled_diff` to only query diffs from earlier blocks

With these changes, we would still expect inserts to proceed very slowly, but hopefully would be attempting many thousands fewer of them.

We could potentially speed up inserts by updating the `create_back_filled_diff` function to remove the query for the previous storage value with the same address + key, but this would result in duplicate inserts of non-zero values across blocks (increasing row count and potentially causing slower queries down the line). 