### PR TITLE
Add storage_diff_checked_index

### DIFF
--- a/db/migrations/20200414084022_add_storage_diff_checked_index.sql
+++ b/db/migrations/20200414084022_add_storage_diff_checked_index.sql
@@ -1,7 +1,6 @@
 -- +goose Up
-create index storage_diff_checked_index on storage_diff(checked);
+CREATE INDEX storage_diff_checked_index ON public.storage_diff (checked);
 
 
 -- +goose Down
-drop index storage_diff_checked_index;
-
+DROP INDEX storage_diff_checked_index;

--- a/db/migrations/20200414084022_add_storage_diff_checked_index.sql
+++ b/db/migrations/20200414084022_add_storage_diff_checked_index.sql
@@ -1,5 +1,5 @@
 -- +goose Up
-CREATE INDEX storage_diff_checked_index ON public.storage_diff (checked);
+CREATE INDEX storage_diff_checked_index ON public.storage_diff (checked) WHERE checked is false;
 
 
 -- +goose Down

--- a/db/migrations/20200414084022_add_storage_diff_checked_index.sql
+++ b/db/migrations/20200414084022_add_storage_diff_checked_index.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+create index storage_diff_checked_index on storage_diff(checked);
+
+
+-- +goose Down
+drop index storage_diff_checked_index;
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -747,6 +747,13 @@ CREATE INDEX receipts_transaction ON public.receipts USING btree (transaction_id
 
 
 --
+-- Name: storage_diff_checked_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX storage_diff_checked_index ON public.storage_diff USING btree (checked);
+
+
+--
 -- Name: transactions_header; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/libraries/shared/storage/diff_repository.go
+++ b/libraries/shared/storage/diff_repository.go
@@ -63,7 +63,7 @@ func (repository diffRepository) CreateBackFilledStorageValue(rawDiff types.RawD
 }
 
 func (repository diffRepository) GetNewDiffs(diffs chan types.PersistedDiff, errs chan error, done chan bool) {
-	rows, queryErr := repository.db.Queryx(`SELECT * FROM public.storage_diff WHERE checked = false`)
+	rows, queryErr := repository.db.Queryx(`SELECT * FROM public.storage_diff WHERE checked IS false`)
 	if queryErr != nil {
 		logrus.Errorf("error getting unchecked storage diffs: %s", queryErr.Error())
 		if rows != nil {


### PR DESCRIPTION
Results from postgres `EXPLAIN` show that the cost of performing the query to get unchecked storage diffs is much less when there's an index on the storage_diff `checked` column:


-  **WITHOUT** an index on checked column

```
QUERY PLAN
----------------------------------------------------------------------------------
Gather  (cost=1000.00..590688.80 rows=1 width=150)
Workers Planned: 2
->  Parallel Seq Scan on storage_diff  (cost=0.00..589688.70 rows=1 width=150)
Filter: (NOT checked)
(4 rows)
```
-  **WITH** an index on checked column
```
QUERY PLAN
-------------------------------------------------------------------------------------------------
Index Scan using storage_diff_checked_index on storage_diff  (cost=0.44..4.46 rows=1 width=150)
Index Cond: (checked = false)
Filter: (NOT checked)
(3 rows)
```

Also, the performance affects of inserting `storage_diffs` seems to be minimal:
- **WITHOUT** an index on checked column 
```
QUERY PLAN |   |  
------------------------------------------------------------ |   |  
Insert on storage_diff  (cost=0.00..0.01 rows=1 width=146) |   |  
Conflict Resolution: NOTHING |   |  
->  Result  (cost=0.00..0.01 rows=1 width=146) |   |  
(3 rows) | 
```

- **WITH** an index on checked column
```
QUERY PLAN |   |  
------------------------------------------------------------ |   |  
Insert on storage_diff  (cost=0.00..0.01 rows=1 width=146) |   |  
Conflict Resolution: NOTHING |   |  
->  Result  (cost=0.00..0.01 rows=1 width=146) |   |  
(3 rows) 
```


