### PR TITLE
Modify query for getting untransformed logs

### DIFF
--- a/pkg/datastore/postgres/repositories/event_log_repository.go
+++ b/pkg/datastore/postgres/repositories/event_log_repository.go
@@ -57,7 +57,7 @@ type rawEventLog struct {
 }
 
 func (repo EventLogRepository) GetUntransformedEventLogs() ([]core.EventLog, error) {
-	rows, queryErr := repo.db.Queryx(`SELECT * FROM public.event_logs WHERE transformed = false`)
+	rows, queryErr := repo.db.Queryx(`SELECT * FROM public.event_logs WHERE transformed is false`)
 	if queryErr != nil {
 		return nil, queryErr
 	}


### PR DESCRIPTION
- use "is" instead of "=" in comparison to match partial index