### PR TITLE
Remove yarn install from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ go_import_path: github.com/makerdao/vulcanizedb
 before_install:
 - make installtools
 - bash ./scripts/install-postgres-11.sh
-- curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-- echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-- sudo apt-get update && sudo apt-get install yarn python3-pip -y
+- sudo apt-get update && sudo apt-get install python3-pip -y
 - sudo pip3 install awscli
 script:
 - env GO111MODULE=on make test


### PR DESCRIPTION
- Install was failing with "Bad header line" and it's no longer
  required for the build