### PR TITLE
Limit unchecked diffs

### DIFF
--- a/libraries/shared/mocks/storage_diff_repository.go
+++ b/libraries/shared/mocks/storage_diff_repository.go
@@ -26,6 +26,8 @@ type MockStorageDiffRepository struct {
 	CreatePassedRawDiffs                       []types.RawDiff
 	GetNewDiffsDiffs                           []types.PersistedDiff
 	GetNewDiffsErrors                          []error
+	GetNewDiffsPassedMinIDs                    []int
+	GetNewDiffsPassedLimits                    []int
 	MarkCheckedPassedID                        int64
 }
 
@@ -39,7 +41,9 @@ func (repository *MockStorageDiffRepository) CreateBackFilledStorageValue(rawDif
 	return repository.CreateBackFilledStorageValueReturnError
 }
 
-func (repository *MockStorageDiffRepository) GetNewDiffs() ([]types.PersistedDiff, error) {
+func (repository *MockStorageDiffRepository) GetNewDiffs(minID, limit int) ([]types.PersistedDiff, error) {
+	repository.GetNewDiffsPassedMinIDs = append(repository.GetNewDiffsPassedMinIDs, minID)
+	repository.GetNewDiffsPassedLimits = append(repository.GetNewDiffsPassedLimits, limit)
 	err := repository.GetNewDiffsErrors[0]
 	if len(repository.GetNewDiffsErrors) > 1 {
 		repository.GetNewDiffsErrors = repository.GetNewDiffsErrors[1:]

--- a/libraries/shared/mocks/storage_diff_repository.go
+++ b/libraries/shared/mocks/storage_diff_repository.go
@@ -39,13 +39,12 @@ func (repository *MockStorageDiffRepository) CreateBackFilledStorageValue(rawDif
 	return repository.CreateBackFilledStorageValueReturnError
 }
 
-func (repository *MockStorageDiffRepository) GetNewDiffs(diffs chan types.PersistedDiff, errs chan error, done chan bool) {
-	for _, diff := range repository.GetNewDiffsDiffs {
-		diffs <- diff
+func (repository *MockStorageDiffRepository) GetNewDiffs() ([]types.PersistedDiff, error) {
+	err := repository.GetNewDiffsErrors[0]
+	if len(repository.GetNewDiffsErrors) > 1 {
+		repository.GetNewDiffsErrors = repository.GetNewDiffsErrors[1:]
 	}
-	for _, err := range repository.GetNewDiffsErrors {
-		errs <- err
-	}
+	return repository.GetNewDiffsDiffs, err
 }
 
 func (repository *MockStorageDiffRepository) MarkChecked(id int64) error {

--- a/libraries/shared/storage/diff_repository_test.go
+++ b/libraries/shared/storage/diff_repository_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Storage diffs repository", func() {
 				fakeRawDiff.StorageKey.Bytes(), fakeRawDiff.StorageValue.Bytes())
 			Expect(insertErr).NotTo(HaveOccurred())
 
-			diffs, err := repo.GetNewDiffs()
+			diffs, err := repo.GetNewDiffs(0, 1)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(diffs).To(ConsistOf(fakePersistedDiff))
@@ -235,10 +235,39 @@ var _ = Describe("Storage diffs repository", func() {
 				fakePersistedDiff.Checked)
 			Expect(insertErr).NotTo(HaveOccurred())
 
-			diffs, err := repo.GetNewDiffs()
+			diffs, err := repo.GetNewDiffs(0, 1)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(diffs).To(BeEmpty())
+		})
+
+		It("enables seeking diffs with greater ID", func() {
+			blockZero := rand.Int()
+			for i := 0; i < 2; i++ {
+				fakeRawDiff := types.RawDiff{
+					HashedAddress: test_data.FakeHash(),
+					BlockHash:     test_data.FakeHash(),
+					BlockHeight:   blockZero + i,
+					StorageKey:    test_data.FakeHash(),
+					StorageValue:  test_data.FakeHash(),
+				}
+				_, insertErr := db.Exec(`INSERT INTO public.storage_diff (block_height, block_hash,
+				hashed_address, storage_key, storage_value) VALUES ($1, $2, $3, $4, $5)`, fakeRawDiff.BlockHeight,
+					fakeRawDiff.BlockHash.Bytes(), fakeRawDiff.HashedAddress.Bytes(), fakeRawDiff.StorageKey.Bytes(),
+					fakeRawDiff.StorageValue.Bytes())
+				Expect(insertErr).NotTo(HaveOccurred())
+			}
+
+			minID := 0
+			limit := 1
+			diffsOne, errOne := repo.GetNewDiffs(minID, limit)
+			Expect(errOne).NotTo(HaveOccurred())
+			Expect(len(diffsOne)).To(Equal(1))
+			nextID := int(diffsOne[0].ID)
+			diffsTwo, errTwo := repo.GetNewDiffs(nextID, limit)
+			Expect(errTwo).NotTo(HaveOccurred())
+			Expect(len(diffsTwo)).To(Equal(1))
+			Expect(int(diffsTwo[0].ID) > nextID).To(BeTrue())
 		})
 	})
 

--- a/libraries/shared/storage/diff_repository_test.go
+++ b/libraries/shared/storage/diff_repository_test.go
@@ -192,9 +192,6 @@ var _ = Describe("Storage diffs repository", func() {
 
 	Describe("GetNewDiffs", func() {
 		It("sends diffs that are not marked as checked", func() {
-			diffs := make(chan types.PersistedDiff)
-			errs := make(chan error)
-			done := make(chan bool)
 			fakeRawDiff := types.RawDiff{
 				HashedAddress: test_data.FakeHash(),
 				BlockHash:     test_data.FakeHash(),
@@ -212,17 +209,13 @@ var _ = Describe("Storage diffs repository", func() {
 				fakeRawDiff.StorageKey.Bytes(), fakeRawDiff.StorageValue.Bytes())
 			Expect(insertErr).NotTo(HaveOccurred())
 
-			go repo.GetNewDiffs(diffs, errs, done)
+			diffs, err := repo.GetNewDiffs()
 
-			Consistently(errs).ShouldNot(Receive())
-			Eventually(<-diffs).Should(Equal(fakePersistedDiff))
-			Eventually(<-done).Should(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(diffs).To(ConsistOf(fakePersistedDiff))
 		})
 
 		It("does not send diff that's marked as checked", func() {
-			diffs := make(chan types.PersistedDiff)
-			errs := make(chan error)
-			done := make(chan bool)
 			fakeRawDiff := types.RawDiff{
 				HashedAddress: test_data.FakeHash(),
 				BlockHash:     test_data.FakeHash(),
@@ -242,11 +235,10 @@ var _ = Describe("Storage diffs repository", func() {
 				fakePersistedDiff.Checked)
 			Expect(insertErr).NotTo(HaveOccurred())
 
-			go repo.GetNewDiffs(diffs, errs, done)
+			diffs, err := repo.GetNewDiffs()
 
-			Consistently(errs).ShouldNot(Receive())
-			Consistently(diffs).ShouldNot(Receive())
-			Eventually(<-done).Should(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(diffs).To(BeEmpty())
 		})
 	})
 

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -32,6 +32,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var ResultsLimit = 500
+
 type ErrHeaderMismatch struct {
 	dbHash   string
 	diffHash string
@@ -89,21 +91,30 @@ func (watcher StorageWatcher) Execute() error {
 }
 
 func (watcher StorageWatcher) transformDiffs() error {
-	diffs, extractErr := watcher.StorageDiffRepository.GetNewDiffs()
-	if extractErr != nil {
-		return fmt.Errorf("error getting unchecked diffs: %s", extractErr.Error())
-	}
-	for _, diff := range diffs {
-		transformErr := watcher.transformDiff(diff)
-		if transformErr != nil {
-			if transformErr == sql.ErrNoRows || reflect.TypeOf(transformErr) == reflect.TypeOf(types.ErrKeyNotFound{}) {
-				logrus.Tracef("error transforming diff: %s", transformErr.Error())
-			} else {
-				logrus.Infof("error transforming diff: %s", transformErr.Error())
+	minID := 0
+	for {
+		diffs, extractErr := watcher.StorageDiffRepository.GetNewDiffs(minID, ResultsLimit)
+		if extractErr != nil {
+			return fmt.Errorf("error getting unchecked diffs: %s", extractErr.Error())
+		}
+		for _, diff := range diffs {
+			transformErr := watcher.transformDiff(diff)
+			if transformErr != nil {
+				if transformErr == sql.ErrNoRows || reflect.TypeOf(transformErr) == reflect.TypeOf(types.ErrKeyNotFound{}) {
+					logrus.Tracef("error transforming diff: %s", transformErr.Error())
+				} else {
+					logrus.Infof("error transforming diff: %s", transformErr.Error())
+				}
 			}
 		}
+		lenDiffs := len(diffs)
+		if lenDiffs > 0 {
+			minID = int(diffs[lenDiffs-1].ID)
+		}
+		if lenDiffs < ResultsLimit {
+			return nil
+		}
 	}
-	return nil
 }
 
 func (watcher StorageWatcher) transformDiff(diff types.PersistedDiff) error {

--- a/libraries/shared/watcher/storage_watcher_test.go
+++ b/libraries/shared/watcher/storage_watcher_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Storage Watcher", func() {
 				ID: rand.Int63(),
 			}
 			mockDiffsRepository.GetNewDiffsDiffs = []types.PersistedDiff{unwatchedDiff}
-			mockDiffsRepository.GetNewDiffsErrors = []error{fakes.FakeError}
+			mockDiffsRepository.GetNewDiffsErrors = []error{nil, fakes.FakeError}
 
 			err := storageWatcher.Execute()
 
@@ -105,8 +105,8 @@ var _ = Describe("Storage Watcher", func() {
 					HeaderID: rand.Int63(),
 				}
 				mockDiffsRepository.GetNewDiffsDiffs = []types.PersistedDiff{diffWithoutHeader}
+				mockDiffsRepository.GetNewDiffsErrors = []error{nil, fakes.FakeError}
 				mockHeaderRepository.GetHeaderError = errors.New("no matching header")
-				mockDiffsRepository.GetNewDiffsErrors = []error{fakes.FakeError}
 
 				err := storageWatcher.Execute()
 
@@ -145,7 +145,7 @@ var _ = Describe("Storage Watcher", func() {
 
 				It("does not mark diff checked if transformer execution fails", func() {
 					mockTransformer.ExecuteErr = errors.New("execute failed")
-					mockDiffsRepository.GetNewDiffsErrors = []error{fakes.FakeError}
+					mockDiffsRepository.GetNewDiffsErrors = []error{nil, fakes.FakeError}
 
 					err := storageWatcher.Execute()
 
@@ -157,7 +157,7 @@ var _ = Describe("Storage Watcher", func() {
 				Describe("when transformer execution succeeds", func() {
 					It("marks diff checked", func() {
 						mockDiffsRepository.GetNewDiffsDiffs = []types.PersistedDiff{fakePersistedDiff}
-						mockDiffsRepository.GetNewDiffsErrors = []error{fakes.FakeError}
+						mockDiffsRepository.GetNewDiffsErrors = []error{nil, fakes.FakeError}
 
 						err := storageWatcher.Execute()
 


### PR DESCRIPTION
- Prevent delay on client write that can happen when we fetch unchecked diffs without a limit
- Seek diffs with ascending ID on subsequent calls so that we're not consistently getting the same diffs
- Reset minimum ID in query to 0 when we receive less than the max results