### PR TITLE
(VDB-1303) Limit results when getting untransformed event logs

### DIFF
--- a/libraries/shared/mocks/log_delegator.go
+++ b/libraries/shared/mocks/log_delegator.go
@@ -22,17 +22,19 @@ import (
 )
 
 type MockLogDelegator struct {
-	AddedTransformers []event.ITransformer
-	DelegateCallCount int
-	DelegateErrors    []error
+	AddedTransformers   []event.ITransformer
+	DelegateCallCount   int
+	DelegateErrors      []error
+	DelegatePassedLimit int
 }
 
 func (delegator *MockLogDelegator) AddTransformer(t event.ITransformer) {
 	delegator.AddedTransformers = append(delegator.AddedTransformers, t)
 }
 
-func (delegator *MockLogDelegator) DelegateLogs() error {
+func (delegator *MockLogDelegator) DelegateLogs(limit int) error {
 	delegator.DelegateCallCount++
+	delegator.DelegatePassedLimit = limit
 	if len(delegator.DelegateErrors) > 1 {
 		var delegateErrorThisRun error
 		delegateErrorThisRun, delegator.DelegateErrors = delegator.DelegateErrors[0], delegator.DelegateErrors[1:]

--- a/libraries/shared/test_data/test_helpers.go
+++ b/libraries/shared/test_data/test_helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/makerdao/vulcanizedb/libraries/shared/watcher"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -37,7 +38,8 @@ func CreateTestLog(headerID int64, db *postgres.DB) core.EventLog {
 	insertLogsErr := eventLogRepository.CreateEventLogs(headerID, []types.Log{log})
 	Expect(insertLogsErr).NotTo(HaveOccurred())
 
-	eventLogs, getLogsErr := eventLogRepository.GetUntransformedEventLogs()
+	// TODO: consider better calibrated limit depending on testing needs
+	eventLogs, getLogsErr := eventLogRepository.GetUntransformedEventLogs(0, watcher.ResultsLimit)
 	Expect(getLogsErr).NotTo(HaveOccurred())
 	for _, eventLog := range eventLogs {
 		if eventLog.Log.TxIndex == log.TxIndex {

--- a/libraries/shared/watcher/event_watcher.go
+++ b/libraries/shared/watcher/event_watcher.go
@@ -99,7 +99,8 @@ func (watcher *EventWatcher) extractLogs(recheckHeaders constants.TransformerExe
 }
 
 func (watcher *EventWatcher) delegateLogs(errs chan error, quitChan chan bool) {
-	watcher.withRetry(watcher.LogDelegator.DelegateLogs, []error{watcher.ExpectedDelegatorError}, "delegating", errs, quitChan)
+	call := func() error { return watcher.LogDelegator.DelegateLogs(ResultsLimit) }
+	watcher.withRetry(call, []error{watcher.ExpectedDelegatorError}, "delegating", errs, quitChan)
 }
 
 func (watcher *EventWatcher) withRetry(call func() error, expectedErrors []error, operation string, errs chan error, quitChan chan bool) {

--- a/libraries/shared/watcher/event_watcher_test.go
+++ b/libraries/shared/watcher/event_watcher_test.go
@@ -162,6 +162,15 @@ var _ = Describe("Event Watcher", func() {
 			Expect(delegator.DelegateCallCount > 0).To(BeTrue())
 		})
 
+		It("passes results limit to delegator", func() {
+			delegator.DelegateErrors = []error{nil, errExecuteClosed}
+
+			err := eventWatcher.Execute(constants.HeaderUnchecked)
+
+			Expect(err).To(MatchError(errExecuteClosed))
+			Expect(delegator.DelegatePassedLimit).To(Equal(watcher.ResultsLimit))
+		})
+
 		It("returns error if delegating logs fails", func() {
 			delegator.DelegateErrors = []error{fakes.FakeError}
 

--- a/pkg/datastore/repository.go
+++ b/pkg/datastore/repository.go
@@ -46,6 +46,6 @@ type HeaderRepository interface {
 }
 
 type EventLogRepository interface {
-	GetUntransformedEventLogs() ([]core.EventLog, error)
+	GetUntransformedEventLogs(minID, limit int) ([]core.EventLog, error)
 	CreateEventLogs(headerID int64, logs []types.Log) error
 }

--- a/pkg/fakes/mock_event_log_repository.go
+++ b/pkg/fakes/mock_event_log_repository.go
@@ -25,14 +25,30 @@ type MockEventLogRepository struct {
 	CreateError    error
 	GetCalled      bool
 	GetError       error
+	PassedMinIDs   []int
+	PassedLimits   []int
 	PassedHeaderID int64
 	PassedLogs     []types.Log
 	ReturnLogs     []core.EventLog
 }
 
-func (repository *MockEventLogRepository) GetUntransformedEventLogs() ([]core.EventLog, error) {
+func (repository *MockEventLogRepository) GetUntransformedEventLogs(minID, limit int) ([]core.EventLog, error) {
 	repository.GetCalled = true
-	return repository.ReturnLogs, repository.GetError
+	repository.PassedMinIDs = append(repository.PassedMinIDs, minID)
+	repository.PassedLimits = append(repository.PassedLimits, limit)
+
+	var returnLogs []core.EventLog
+	if limit >= len(repository.ReturnLogs) {
+		returnLogs = repository.ReturnLogs
+		repository.ReturnLogs = []core.EventLog{}
+	} else {
+		for i := 0; i < limit; i++ {
+			returnLogs = append(returnLogs, repository.ReturnLogs[i])
+		}
+		repository.ReturnLogs = repository.ReturnLogs[limit:]
+	}
+
+	return returnLogs, repository.GetError
 }
 
 func (repository *MockEventLogRepository) CreateEventLogs(headerID int64, logs []types.Log) error {


### PR DESCRIPTION
- Prevent unbounded results sets
- Avoid keeping the connection open while converting raw DB log into
  core.EventLog

Some quirks:
- passing the results limit from the watcher to the delegator, which then passes it to the repository. Did this so that we can tune the results limit for both events + diffs if we find that we want to use a different number. Also avoids an import cycle caused by using `watcher.ResultsLimit` directly from the `Delegator` in the `logs` pkg
- `DelegateLogs` returns an expected error (triggering a retry interval delay) when the repository returns zero logs, but `nil` for error when the repository returns fewer logs than the limit. Doing this because the fact that we've received fewer logs than the limit indicates that there are fewer than `limit` number of logs that are untransformed _with an ID greater than the passed minimum_, but not necessarily that we have exhausted all untransformed logs.
- Continuing with the `minID` pattern used for limiting unchecked diffs because there's a similar possibility here for persistently untransformed logs - since we fetch logs that match a collection of addresses + a collection of topic0s, it's possible that we'll have logs that match an address + topic0 in the collection but are not currently being transformed.