### PR TITLE
Modify unchecked diffs query

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -76,7 +76,7 @@ func init() {
 	executeCmd.Flags().BoolVarP(&recheckHeadersArg, "recheck-headers", "r", false, "whether to re-check headers for watched events")
 	executeCmd.Flags().DurationVarP(&retryInterval, "retry-interval", "i", 7*time.Second, "interval duration between retries on execution error")
 	executeCmd.Flags().IntVarP(&maxUnexpectedErrors, "max-unexpected-errs", "m", 5, "maximum number of unexpected errors to allow (with retries) before exiting")
-	executeCmd.Flags().BoolVarP(&skipOldDiffs, "skip-old-diffs", "s", false, "whether to skip checking storage diffs that are from blocks more than 500 back from the head of the chain")
+	executeCmd.Flags().Int64VarP(&diffBlockFromHeadOfChain, "diff-blocks-from-head", "d", -1, "number of blocks from head of chain to start reprocessing diffs, defaults to -1 so all diffs are processsed")
 }
 
 func executeTransformers() {
@@ -105,7 +105,7 @@ func executeTransformers() {
 	}
 
 	if len(ethStorageInitializers) > 0 {
-		sw := watcher.NewStorageWatcher(&db, retryInterval, skipOldDiffs)
+		sw := watcher.NewStorageWatcher(&db, retryInterval, diffBlockFromHeadOfChain)
 		sw.AddTransformers(ethStorageInitializers)
 		wg.Add(1)
 		go watchEthStorage(&sw, &wg)

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -104,7 +104,7 @@ func executeTransformers() {
 	}
 
 	if len(ethStorageInitializers) > 0 {
-		sw := watcher.NewStorageWatcher(&db, retryInterval)
+		sw := watcher.NewStorageWatcher(&db, retryInterval, false)
 		sw.AddTransformers(ethStorageInitializers)
 		wg.Add(1)
 		go watchEthStorage(&sw, &wg)

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -76,6 +76,7 @@ func init() {
 	executeCmd.Flags().BoolVarP(&recheckHeadersArg, "recheck-headers", "r", false, "whether to re-check headers for watched events")
 	executeCmd.Flags().DurationVarP(&retryInterval, "retry-interval", "i", 7*time.Second, "interval duration between retries on execution error")
 	executeCmd.Flags().IntVarP(&maxUnexpectedErrors, "max-unexpected-errs", "m", 5, "maximum number of unexpected errors to allow (with retries) before exiting")
+	executeCmd.Flags().BoolVarP(&skipOldDiffs, "skip-old-diffs", "s", false, "whether to skip checking storage diffs that are from blocks more than 500 back from the head of the chain")
 }
 
 func executeTransformers() {
@@ -104,7 +105,7 @@ func executeTransformers() {
 	}
 
 	if len(ethStorageInitializers) > 0 {
-		sw := watcher.NewStorageWatcher(&db, retryInterval, false)
+		sw := watcher.NewStorageWatcher(&db, retryInterval, skipOldDiffs)
 		sw.AddTransformers(ethStorageInitializers)
 		wg.Add(1)
 		go watchEthStorage(&sw, &wg)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,7 @@ var (
 	maxUnexpectedErrors int
 	recheckHeadersArg   bool
 	retryInterval       time.Duration
+	skipOldDiffs        bool
 	startingBlockNumber int64
 	storageDiffsPath    string
 	storageDiffsSource  string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,19 +40,19 @@ import (
 )
 
 var (
-	LogWithCommand      logrus.Entry
-	SubCommand          string
-	cfgFile             string
-	databaseConfig      config.Database
-	genConfig           config.Plugin
-	ipc                 string
-	maxUnexpectedErrors int
-	recheckHeadersArg   bool
-	retryInterval       time.Duration
-	skipOldDiffs        bool
-	startingBlockNumber int64
-	storageDiffsPath    string
-	storageDiffsSource  string
+	LogWithCommand           logrus.Entry
+	SubCommand               string
+	cfgFile                  string
+	databaseConfig           config.Database
+	diffBlockFromHeadOfChain int64
+	genConfig                config.Plugin
+	ipc                      string
+	maxUnexpectedErrors      int
+	recheckHeadersArg        bool
+	retryInterval            time.Duration
+	startingBlockNumber      int64
+	storageDiffsPath         string
+	storageDiffsSource       string
 )
 
 const (

--- a/libraries/shared/mocks/storage_diff_repository.go
+++ b/libraries/shared/mocks/storage_diff_repository.go
@@ -63,4 +63,3 @@ func (repository *MockStorageDiffRepository) GetFirstDiffForBlockHeight(blockHei
 	repository.GetFirstDiffBlockHeightPassed = blockHeight
 	return repository.GetFirstDiffToReturn, repository.GetFirstDiffErr
 }
-

--- a/libraries/shared/mocks/storage_diff_repository.go
+++ b/libraries/shared/mocks/storage_diff_repository.go
@@ -30,7 +30,7 @@ type MockStorageDiffRepository struct {
 	GetNewDiffsPassedLimits                    []int
 	MarkCheckedPassedID                        int64
 	GetFirstDiffIDToReturn                     int64
-	GetFirstDiffErr                            error
+	GetFirstDiffIDErr                          error
 	GetFirstDiffBlockHeightPassed              int64
 }
 
@@ -61,5 +61,5 @@ func (repository *MockStorageDiffRepository) MarkChecked(id int64) error {
 
 func (repository *MockStorageDiffRepository) GetFirstDiffIDForBlockHeight(blockHeight int64) (int64, error) {
 	repository.GetFirstDiffBlockHeightPassed = blockHeight
-	return repository.GetFirstDiffIDToReturn, repository.GetFirstDiffErr
+	return repository.GetFirstDiffIDToReturn, repository.GetFirstDiffIDErr
 }

--- a/libraries/shared/mocks/storage_diff_repository.go
+++ b/libraries/shared/mocks/storage_diff_repository.go
@@ -55,3 +55,8 @@ func (repository *MockStorageDiffRepository) MarkChecked(id int64) error {
 	repository.MarkCheckedPassedID = id
 	return nil
 }
+
+func (repository *MockStorageDiffRepository) GetFirstDiffForBlockHeight(blockHeight int64) (types.PersistedDiff, error) {
+	return types.PersistedDiff{}, nil
+}
+

--- a/libraries/shared/mocks/storage_diff_repository.go
+++ b/libraries/shared/mocks/storage_diff_repository.go
@@ -29,7 +29,7 @@ type MockStorageDiffRepository struct {
 	GetNewDiffsPassedMinIDs                    []int
 	GetNewDiffsPassedLimits                    []int
 	MarkCheckedPassedID                        int64
-	GetFirstDiffToReturn                       types.PersistedDiff
+	GetFirstDiffIDToReturn                     int64
 	GetFirstDiffErr                            error
 	GetFirstDiffBlockHeightPassed              int64
 }
@@ -59,7 +59,7 @@ func (repository *MockStorageDiffRepository) MarkChecked(id int64) error {
 	return nil
 }
 
-func (repository *MockStorageDiffRepository) GetFirstDiffForBlockHeight(blockHeight int64) (types.PersistedDiff, error) {
+func (repository *MockStorageDiffRepository) GetFirstDiffIDForBlockHeight(blockHeight int64) (int64, error) {
 	repository.GetFirstDiffBlockHeightPassed = blockHeight
-	return repository.GetFirstDiffToReturn, repository.GetFirstDiffErr
+	return repository.GetFirstDiffIDToReturn, repository.GetFirstDiffErr
 }

--- a/libraries/shared/mocks/storage_diff_repository.go
+++ b/libraries/shared/mocks/storage_diff_repository.go
@@ -29,6 +29,9 @@ type MockStorageDiffRepository struct {
 	GetNewDiffsPassedMinIDs                    []int
 	GetNewDiffsPassedLimits                    []int
 	MarkCheckedPassedID                        int64
+	GetFirstDiffToReturn                       types.PersistedDiff
+	GetFirstDiffErr                            error
+	GetFirstDiffBlockHeightPassed              int64
 }
 
 func (repository *MockStorageDiffRepository) CreateStorageDiff(rawDiff types.RawDiff) (int64, error) {
@@ -57,6 +60,7 @@ func (repository *MockStorageDiffRepository) MarkChecked(id int64) error {
 }
 
 func (repository *MockStorageDiffRepository) GetFirstDiffForBlockHeight(blockHeight int64) (types.PersistedDiff, error) {
-	return types.PersistedDiff{}, nil
+	repository.GetFirstDiffBlockHeightPassed = blockHeight
+	return repository.GetFirstDiffToReturn, repository.GetFirstDiffErr
 }
 

--- a/libraries/shared/storage/diff_repository.go
+++ b/libraries/shared/storage/diff_repository.go
@@ -78,7 +78,7 @@ func (repository diffRepository) MarkChecked(id int64) error {
 func (repository diffRepository) GetFirstDiffIDForBlockHeight(blockHeight int64) (int64, error) {
 	var diffID int64
 	err := repository.db.Get(&diffID,
-		`SELECT id FROM public.storage_diff WHERE checked IS false AND block_height >= $1 LIMIT 1`, blockHeight)
+		`SELECT id FROM public.storage_diff WHERE block_height >= $1 LIMIT 1`, blockHeight)
 
 	return diffID, err
 }

--- a/libraries/shared/storage/diff_repository.go
+++ b/libraries/shared/storage/diff_repository.go
@@ -31,6 +31,7 @@ type DiffRepository interface {
 	CreateBackFilledStorageValue(rawDiff types.RawDiff) error
 	GetNewDiffs(minID, limit int) ([]types.PersistedDiff, error)
 	MarkChecked(id int64) error
+    GetFirstDiffForBlockHeight(blockHeight int64) (types.PersistedDiff, error)
 }
 
 type diffRepository struct {
@@ -72,4 +73,12 @@ func (repository diffRepository) GetNewDiffs(minID, limit int) ([]types.Persiste
 func (repository diffRepository) MarkChecked(id int64) error {
 	_, err := repository.db.Exec(`UPDATE public.storage_diff SET checked = true WHERE id = $1`, id)
 	return err
+}
+
+func (repository diffRepository) GetFirstDiffForBlockHeight(blockHeight int64) (types.PersistedDiff, error) {
+	var diff types.PersistedDiff
+	err := repository.db.Get(&diff,
+		`SELECT * FROM public.storage_diff WHERE checked IS false AND block_height = $1 LIMIT 1`, blockHeight)
+
+	return diff, err
 }

--- a/libraries/shared/storage/diff_repository.go
+++ b/libraries/shared/storage/diff_repository.go
@@ -31,7 +31,7 @@ type DiffRepository interface {
 	CreateBackFilledStorageValue(rawDiff types.RawDiff) error
 	GetNewDiffs(minID, limit int) ([]types.PersistedDiff, error)
 	MarkChecked(id int64) error
-    GetFirstDiffForBlockHeight(blockHeight int64) (types.PersistedDiff, error)
+	GetFirstDiffForBlockHeight(blockHeight int64) (types.PersistedDiff, error)
 }
 
 type diffRepository struct {

--- a/libraries/shared/storage/diff_repository.go
+++ b/libraries/shared/storage/diff_repository.go
@@ -31,7 +31,7 @@ type DiffRepository interface {
 	CreateBackFilledStorageValue(rawDiff types.RawDiff) error
 	GetNewDiffs(minID, limit int) ([]types.PersistedDiff, error)
 	MarkChecked(id int64) error
-	GetFirstDiffForBlockHeight(blockHeight int64) (types.PersistedDiff, error)
+	GetFirstDiffIDForBlockHeight(blockHeight int64) (int64, error)
 }
 
 type diffRepository struct {
@@ -75,10 +75,10 @@ func (repository diffRepository) MarkChecked(id int64) error {
 	return err
 }
 
-func (repository diffRepository) GetFirstDiffForBlockHeight(blockHeight int64) (types.PersistedDiff, error) {
-	var diff types.PersistedDiff
-	err := repository.db.Get(&diff,
-		`SELECT * FROM public.storage_diff WHERE checked IS false AND block_height = $1 LIMIT 1`, blockHeight)
+func (repository diffRepository) GetFirstDiffIDForBlockHeight(blockHeight int64) (int64, error) {
+	var diffID int64
+	err := repository.db.Get(&diffID,
+		`SELECT id FROM public.storage_diff WHERE checked IS false AND block_height >= $1 LIMIT 1`, blockHeight)
 
-	return diff, err
+	return diffID, err
 }

--- a/libraries/shared/storage/diff_repository_test.go
+++ b/libraries/shared/storage/diff_repository_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Storage diffs repository", func() {
 		})
 	})
 
-	Describe("GetFirstDiffForBlockHeight", func() {
+	Describe("GetFirstDiffIDForBlockHeight", func() {
 		It("sends first diff for a given block height", func() {
 			blockHeight := fakeStorageDiff.BlockHeight
 			fakeStorageDiff2 := types.RawDiff{
@@ -318,13 +318,34 @@ var _ = Describe("Storage diffs repository", func() {
 			_, create2Err := repo.CreateStorageDiff(fakeStorageDiff2)
 			Expect(create2Err).NotTo(HaveOccurred())
 
-			diff, diffErr := repo.GetFirstDiffForBlockHeight(int64(blockHeight))
+			diffID, diffErr := repo.GetFirstDiffIDForBlockHeight(int64(blockHeight))
 			Expect(diffErr).NotTo(HaveOccurred())
-			Expect(diff.ID).To(Equal(id1))
+			Expect(diffID).To(Equal(id1))
+		})
+
+		It("sends a diff for the next block height if one doesn't exist for the block passed in", func() {
+			blockHeight := fakeStorageDiff.BlockHeight
+			fakeStorageDiff2 := types.RawDiff{
+				HashedAddress: test_data.FakeHash(),
+				BlockHash:     test_data.FakeHash(),
+				BlockHeight:   blockHeight,
+				StorageKey:    test_data.FakeHash(),
+				StorageValue:  test_data.FakeHash(),
+			}
+
+			id1, create1Err := repo.CreateStorageDiff(fakeStorageDiff)
+			Expect(create1Err).NotTo(HaveOccurred())
+			_, create2Err := repo.CreateStorageDiff(fakeStorageDiff2)
+			Expect(create2Err).NotTo(HaveOccurred())
+
+			blockBeforeDiffBlockHeight := int64(blockHeight - 1)
+			diffID, diffErr := repo.GetFirstDiffIDForBlockHeight(blockBeforeDiffBlockHeight)
+			Expect(diffErr).NotTo(HaveOccurred())
+			Expect(diffID).To(Equal(id1))
 		})
 
 		It("returns an error if getting the diff fails", func() {
-			_, diffErr := repo.GetFirstDiffForBlockHeight(0)
+			_, diffErr := repo.GetFirstDiffIDForBlockHeight(0)
 			Expect(diffErr).To(HaveOccurred())
 			Expect(diffErr).To(MatchError(sql.ErrNoRows))
 		})

--- a/libraries/shared/storage/diff_repository_test.go
+++ b/libraries/shared/storage/diff_repository_test.go
@@ -301,4 +301,33 @@ var _ = Describe("Storage diffs repository", func() {
 			Expect(checked).To(BeTrue())
 		})
 	})
+
+	Describe("GetFirstDiffForBlockHeight", func() {
+		It("sends first diff for a given block height", func() {
+			blockHeight := fakeStorageDiff.BlockHeight
+			fakeStorageDiff2 := types.RawDiff{
+				HashedAddress: test_data.FakeHash(),
+				BlockHash:     test_data.FakeHash(),
+				BlockHeight:   blockHeight,
+				StorageKey:    test_data.FakeHash(),
+				StorageValue:  test_data.FakeHash(),
+			}
+
+			id1, create1Err := repo.CreateStorageDiff(fakeStorageDiff)
+			Expect(create1Err).NotTo(HaveOccurred())
+			_, create2Err := repo.CreateStorageDiff(fakeStorageDiff2)
+			Expect(create2Err).NotTo(HaveOccurred())
+
+			diff, diffErr := repo.GetFirstDiffForBlockHeight(int64(blockHeight))
+			Expect(diffErr).NotTo(HaveOccurred())
+			Expect(diff.ID).To(Equal(id1))
+		})
+
+		It("returns an error if getting the diff fails", func() {
+			_, diffErr := repo.GetFirstDiffForBlockHeight(0)
+			Expect(diffErr).To(HaveOccurred())
+			Expect(diffErr).To(MatchError(sql.ErrNoRows))
+		})
+	})
 })
+

--- a/libraries/shared/storage/diff_repository_test.go
+++ b/libraries/shared/storage/diff_repository_test.go
@@ -364,9 +364,14 @@ var _ = Describe("Storage diffs repository", func() {
 				fakePersistedDiff.Checked)
 			Expect(insertErr).NotTo(HaveOccurred())
 
+			var insertedDiffID int64
+			getInsertedDiffIDErr := db.Get(&insertedDiffID, `SELECT id FROM storage_diff LIMIT 1`)
+			Expect(getInsertedDiffIDErr).NotTo(HaveOccurred())
+
 			blockBeforeDiffBlockHeight := int64(fakeRawDiff.BlockHeight - 1)
-			_, diffErr := repo.GetFirstDiffIDForBlockHeight(blockBeforeDiffBlockHeight)
+			diffID, diffErr := repo.GetFirstDiffIDForBlockHeight(blockBeforeDiffBlockHeight)
 			Expect(diffErr).NotTo(HaveOccurred())
+			Expect(diffID).To(Equal(insertedDiffID))
 		})
 
 		It("returns an error if getting the diff fails", func() {

--- a/libraries/shared/storage/diff_repository_test.go
+++ b/libraries/shared/storage/diff_repository_test.go
@@ -330,4 +330,3 @@ var _ = Describe("Storage diffs repository", func() {
 		})
 	})
 })
-

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -32,10 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	ResultsLimit       = 500
-	BlocksBackFromHead = int64(500)
-)
+var ResultsLimit = 500
 
 type ErrHeaderMismatch struct {
 	dbHash   string
@@ -96,7 +93,7 @@ func (watcher StorageWatcher) Execute() error {
 }
 
 func (watcher StorageWatcher) getMinDiffID() (int, error) {
-	var minID int
+	var minID = 0
 	if watcher.DiffBlocksFromHeadOfChain != -1 {
 		mostRecentHeaderBlockNumber, getHeaderErr := watcher.HeaderRepository.GetMostRecentHeaderBlockNumber()
 		if getHeaderErr != nil {
@@ -108,7 +105,10 @@ func (watcher StorageWatcher) getMinDiffID() (int, error) {
 			return 0, getDiffErr
 		}
 
-		minID = int(diffID - 1)
+		// We are subtracting an offset from the diffID because it will be passed to GetNewDiffs which returns diffs with ids
+		// greater than id passed in (minID), and we want to make sure that this diffID here is included in that collection
+		diffOffset := int64(1)
+		minID = int(diffID - diffOffset)
 	}
 
 	return minID, nil

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	ResultsLimit = 500
+	ResultsLimit       = 500
 	BlocksBackFromHead = int64(500)
 )
 
@@ -103,7 +103,7 @@ func (watcher StorageWatcher) transformDiffs() error {
 			return getHeaderErr
 		}
 		blockNumber := mostRecentHeader.BlockNumber - BlocksBackFromHead
-		diff, getDiffErr  := watcher.StorageDiffRepository.GetFirstDiffForBlockHeight(blockNumber)
+		diff, getDiffErr := watcher.StorageDiffRepository.GetFirstDiffForBlockHeight(blockNumber)
 		if getDiffErr != nil {
 			return getDiffErr
 		}

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -108,7 +108,7 @@ func (watcher StorageWatcher) transformDiffs() error {
 			return getDiffErr
 		}
 
-		minID = int(diffID)
+		minID = int(diffID - 1)
 	}
 
 	for {

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -103,12 +103,12 @@ func (watcher StorageWatcher) transformDiffs() error {
 			return getHeaderErr
 		}
 		blockNumber := mostRecentHeader.BlockNumber - BlocksBackFromHead
-		diff, getDiffErr := watcher.StorageDiffRepository.GetFirstDiffForBlockHeight(blockNumber)
+		diffID, getDiffErr := watcher.StorageDiffRepository.GetFirstDiffIDForBlockHeight(blockNumber)
 		if getDiffErr != nil {
 			return getDiffErr
 		}
 
-		minID = int(diff.ID)
+		minID = int(diffID)
 	}
 
 	for {

--- a/libraries/shared/watcher/storage_watcher_test.go
+++ b/libraries/shared/watcher/storage_watcher_test.go
@@ -161,8 +161,8 @@ var _ = Describe("Storage Watcher", func() {
 					diffs = append(diffs, diff)
 				}
 
-				header := fakes.GetFakeHeader(rand.Int63())
-				mockHeaderRepository.MostRecentHeader = header
+				headerBlockNumber := rand.Int63()
+				mockHeaderRepository.MostRecentHeaderBlockNumber = headerBlockNumber
 
 				mockDiffsRepository.GetFirstDiffIDToReturn = diffs[0].ID
 				mockDiffsRepository.GetNewDiffsDiffs = diffs
@@ -175,7 +175,7 @@ var _ = Describe("Storage Watcher", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(MatchRegexp(fakes.FakeError.Error()))
-				Expect(mockDiffsRepository.GetFirstDiffBlockHeightPassed).To(Equal(header.BlockNumber - watcher.BlocksBackFromHead))
+				Expect(mockDiffsRepository.GetFirstDiffBlockHeightPassed).To(Equal(headerBlockNumber - watcher.BlocksBackFromHead))
 				Expect(mockDiffsRepository.GetNewDiffsPassedMinIDs).To(ConsistOf(expectedFirstMinDiffID, expectedSecondMinDiffID))
 			})
 
@@ -193,8 +193,8 @@ var _ = Describe("Storage Watcher", func() {
 					diffs = append(diffs, diff)
 				}
 
-				header := fakes.GetFakeHeader(rand.Int63())
-				mockHeaderRepository.MostRecentHeader = header
+				headerBlockNumber := rand.Int63()
+				mockHeaderRepository.MostRecentHeaderBlockNumber = headerBlockNumber
 
 				mockDiffsRepository.GetFirstDiffIDToReturn = diffs[0].ID
 				mockDiffsRepository.GetNewDiffsDiffs = diffs
@@ -206,7 +206,7 @@ var _ = Describe("Storage Watcher", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(MatchRegexp(fakes.FakeError.Error()))
-				Expect(mockDiffsRepository.GetFirstDiffBlockHeightPassed).To(Equal(header.BlockNumber - watcher.BlocksBackFromHead))
+				Expect(mockDiffsRepository.GetFirstDiffBlockHeightPassed).To(Equal(headerBlockNumber - watcher.BlocksBackFromHead))
 				Expect(mockDiffsRepository.GetNewDiffsPassedMinIDs).To(ConsistOf(expectedFirstMinDiffID, expectedFirstMinDiffID))
 			})
 		})

--- a/libraries/shared/watcher/storage_watcher_test.go
+++ b/libraries/shared/watcher/storage_watcher_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Storage Watcher", func() {
 				mockDiffsRepository.GetNewDiffsErrors = []error{nil, fakes.FakeError}
 
 				expectedFirstMinDiffID := int(diffs[0].ID)
-				expectedSecondMinDiffID := int(diffs[len(diffs) - 1].ID)
+				expectedSecondMinDiffID := int(diffs[len(diffs)-1].ID)
 
 				err := storageWatcher.Execute()
 

--- a/libraries/shared/watcher/storage_watcher_test.go
+++ b/libraries/shared/watcher/storage_watcher_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Storage Watcher", func() {
 				header := fakes.GetFakeHeader(rand.Int63())
 				mockHeaderRepository.MostRecentHeader = header
 
-				mockDiffsRepository.GetFirstDiffToReturn = diffs[0]
+				mockDiffsRepository.GetFirstDiffIDToReturn = diffs[0].ID
 				mockDiffsRepository.GetNewDiffsDiffs = diffs
 				mockDiffsRepository.GetNewDiffsErrors = []error{nil, fakes.FakeError}
 
@@ -194,7 +194,7 @@ var _ = Describe("Storage Watcher", func() {
 				header := fakes.GetFakeHeader(rand.Int63())
 				mockHeaderRepository.MostRecentHeader = header
 
-				mockDiffsRepository.GetFirstDiffToReturn = diffs[0]
+				mockDiffsRepository.GetFirstDiffIDToReturn = diffs[0].ID
 				mockDiffsRepository.GetNewDiffsDiffs = diffs
 				mockDiffsRepository.GetNewDiffsErrors = []error{nil, fakes.FakeError}
 

--- a/libraries/shared/watcher/storage_watcher_test.go
+++ b/libraries/shared/watcher/storage_watcher_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Storage Watcher", func() {
 				mockDiffsRepository.GetNewDiffsDiffs = diffs
 				mockDiffsRepository.GetNewDiffsErrors = []error{nil, fakes.FakeError}
 
-				expectedFirstMinDiffID := int(diffs[0].ID)
+				expectedFirstMinDiffID := int(diffs[0].ID - 1)
 				expectedSecondMinDiffID := int(diffs[len(diffs)-1].ID)
 
 				err := storageWatcher.Execute()
@@ -200,7 +200,7 @@ var _ = Describe("Storage Watcher", func() {
 				mockDiffsRepository.GetNewDiffsDiffs = diffs
 				mockDiffsRepository.GetNewDiffsErrors = []error{nil, fakes.FakeError}
 
-				expectedFirstMinDiffID := int(diffs[0].ID)
+				expectedFirstMinDiffID := int(diffs[0].ID - 1)
 
 				err := storageWatcher.Execute()
 

--- a/libraries/shared/watcher/storage_watcher_test.go
+++ b/libraries/shared/watcher/storage_watcher_test.go
@@ -138,9 +138,9 @@ var _ = Describe("Storage Watcher", func() {
 
 		Describe("When the watcher is configured to skip old diffs", func() {
 			var diffs []types.PersistedDiff
+			var numberOfBlocksFromHeadOfChain = int64(500)
 
 			BeforeEach(func() {
-				numberOfBlocksFromHeadOfChain := int64(500)
 				storageWatcher = watcher.StorageWatcher{
 					HeaderRepository:          mockHeaderRepository,
 					StorageDiffRepository:     mockDiffsRepository,
@@ -176,7 +176,7 @@ var _ = Describe("Storage Watcher", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(MatchRegexp(fakes.FakeError.Error()))
-				Expect(mockDiffsRepository.GetFirstDiffBlockHeightPassed).To(Equal(headerBlockNumber - watcher.BlocksBackFromHead))
+				Expect(mockDiffsRepository.GetFirstDiffBlockHeightPassed).To(Equal(headerBlockNumber - numberOfBlocksFromHeadOfChain))
 				Expect(mockDiffsRepository.GetNewDiffsPassedMinIDs).To(ConsistOf(expectedFirstMinDiffID, expectedSecondMinDiffID))
 			})
 
@@ -207,7 +207,7 @@ var _ = Describe("Storage Watcher", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(MatchRegexp(fakes.FakeError.Error()))
-				Expect(mockDiffsRepository.GetFirstDiffBlockHeightPassed).To(Equal(headerBlockNumber - watcher.BlocksBackFromHead))
+				Expect(mockDiffsRepository.GetFirstDiffBlockHeightPassed).To(Equal(headerBlockNumber - numberOfBlocksFromHeadOfChain))
 				Expect(mockDiffsRepository.GetNewDiffsPassedMinIDs).To(ConsistOf(expectedFirstMinDiffID, expectedFirstMinDiffID))
 			})
 
@@ -222,7 +222,7 @@ var _ = Describe("Storage Watcher", func() {
 
 				expectedFirstMinDiffID := 0
 				expectedSecondMinDiffID := int(diffs[len(diffs)-1].ID)
-				Expect(mockDiffsRepository.GetNewDiffsPassedMinIDs).To(ConsistOf(expectedFirstMinDiffID,expectedSecondMinDiffID))
+				Expect(mockDiffsRepository.GetNewDiffsPassedMinIDs).To(ConsistOf(expectedFirstMinDiffID, expectedSecondMinDiffID))
 			})
 
 			It("sets minID to 0 if there are no diffs with given block range", func() {
@@ -236,7 +236,7 @@ var _ = Describe("Storage Watcher", func() {
 
 				expectedFirstMinDiffID := 0
 				expectedSecondMinDiffID := int(diffs[len(diffs)-1].ID)
-				Expect(mockDiffsRepository.GetNewDiffsPassedMinIDs).To(ConsistOf(expectedFirstMinDiffID,expectedSecondMinDiffID))
+				Expect(mockDiffsRepository.GetNewDiffsPassedMinIDs).To(ConsistOf(expectedFirstMinDiffID, expectedSecondMinDiffID))
 			})
 		})
 

--- a/libraries/shared/watcher/storage_watcher_test.go
+++ b/libraries/shared/watcher/storage_watcher_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Storage Watcher", func() {
 		It("adds transformers", func() {
 			fakeHashedAddress := types.HexToKeccak256Hash("0x12345")
 			fakeTransformer := &mocks.MockStorageTransformer{KeccakOfAddress: fakeHashedAddress}
-			w := watcher.NewStorageWatcher(test_config.NewTestDB(test_config.NewTestNode()), time.Nanosecond, false)
+			w := watcher.NewStorageWatcher(test_config.NewTestDB(test_config.NewTestNode()), time.Nanosecond, -1)
 
 			w.AddTransformers([]storage.TransformerInitializer{fakeTransformer.FakeTransformerInitializer})
 
@@ -61,6 +61,7 @@ var _ = Describe("Storage Watcher", func() {
 				StorageDiffRepository:     mockDiffsRepository,
 				KeccakAddressTransformers: map[common.Hash]storage.ITransformer{},
 				RetryInterval:             time.Nanosecond,
+				DiffBlocksFromHeadOfChain: -1,
 			}
 		})
 
@@ -134,14 +135,15 @@ var _ = Describe("Storage Watcher", func() {
 			Expect(mockDiffsRepository.MarkCheckedPassedID).To(Equal(unwatchedDiff.ID))
 		})
 
-		Describe("When SkipOldDiffs is configured", func() {
+		Describe("When the watcher is configured to skip old diffs", func() {
 			BeforeEach(func() {
+				numberOfBlocksFromHeadOfChain := int64(500)
 				storageWatcher = watcher.StorageWatcher{
 					HeaderRepository:          mockHeaderRepository,
 					StorageDiffRepository:     mockDiffsRepository,
 					KeccakAddressTransformers: map[common.Hash]storage.ITransformer{},
 					RetryInterval:             time.Nanosecond,
-					SkipOldDiffs:              true,
+					DiffBlocksFromHeadOfChain: numberOfBlocksFromHeadOfChain,
 				}
 			})
 

--- a/pkg/datastore/postgres/repositories/header_repository.go
+++ b/pkg/datastore/postgres/repositories/header_repository.go
@@ -107,3 +107,11 @@ func (repository HeaderRepository) MissingBlockNumbers(startingBlockNumber, endi
 	}
 	return numbers, nil
 }
+
+func (repository HeaderRepository) GetMostRecentHeader() (core.Header, error) {
+	var header core.Header
+	err := repository.database.Get(&header,
+		`SELECT id, block_number, hash, raw, block_timestamp FROM headers ORDER BY block_number DESC LIMIT 1`)
+
+	return header, err
+}

--- a/pkg/datastore/postgres/repositories/header_repository.go
+++ b/pkg/datastore/postgres/repositories/header_repository.go
@@ -108,10 +108,10 @@ func (repository HeaderRepository) MissingBlockNumbers(startingBlockNumber, endi
 	return numbers, nil
 }
 
-func (repository HeaderRepository) GetMostRecentHeader() (core.Header, error) {
-	var header core.Header
-	err := repository.database.Get(&header,
-		`SELECT id, block_number, hash, raw, block_timestamp FROM headers ORDER BY block_number DESC LIMIT 1`)
+func (repository HeaderRepository) GetMostRecentHeaderBlockNumber() (int64, error) {
+	var blockNumber int64
+	err := repository.database.Get(&blockNumber,
+		`SELECT block_number FROM headers ORDER BY block_number DESC LIMIT 1`)
 
-	return header, err
+	return blockNumber, err
 }

--- a/pkg/datastore/postgres/repositories/header_repository_test.go
+++ b/pkg/datastore/postgres/repositories/header_repository_test.go
@@ -444,8 +444,8 @@ var _ = Describe("Block header repository", func() {
 		})
 	})
 
-	Describe("GetMostRecentHeader", func() {
-		It("gets the most recent header by block number", func() {
+	Describe("GetMostRecentHeaderBlockNumber", func() {
+		It("gets the most recent header block number", func() {
 			_, createHeader1Err := repo.CreateOrUpdateHeader(header)
 			Expect(createHeader1Err).NotTo(HaveOccurred())
 
@@ -454,13 +454,13 @@ var _ = Describe("Block header repository", func() {
 			_, createHeader2Err := repo.CreateOrUpdateHeader(header2)
 			Expect(createHeader2Err).NotTo(HaveOccurred())
 
-			mostRecentHeader, err := repo.GetMostRecentHeader()
+			mostRecentHeaderBlock, err := repo.GetMostRecentHeaderBlockNumber()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(mostRecentHeader.BlockNumber).To(Equal(header2BlockNumber))
+			Expect(mostRecentHeaderBlock).To(Equal(header2BlockNumber))
 		})
 
 		It("returns an error if it fails to get the most recent header", func() {
-			_, err := repo.GetMostRecentHeader()
+			_, err := repo.GetMostRecentHeaderBlockNumber()
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(sql.ErrNoRows))
 		})

--- a/pkg/datastore/postgres/repositories/header_repository_test.go
+++ b/pkg/datastore/postgres/repositories/header_repository_test.go
@@ -17,6 +17,7 @@
 package repositories_test
 
 import (
+	"database/sql"
 	"math/big"
 	"math/rand"
 
@@ -440,6 +441,28 @@ var _ = Describe("Block header repository", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(missingBlockNumbers).To(ConsistOf([]int64{2, 4}))
+		})
+	})
+
+	Describe("GetMostRecentHeader", func() {
+		It("gets the most recent header by block number", func() {
+			_, createHeader1Err := repo.CreateOrUpdateHeader(header)
+			Expect(createHeader1Err).NotTo(HaveOccurred())
+
+			header2BlockNumber := header.BlockNumber + int64(1)
+			header2 := fakes.GetFakeHeader(header2BlockNumber)
+			_, createHeader2Err := repo.CreateOrUpdateHeader(header2)
+			Expect(createHeader2Err).NotTo(HaveOccurred())
+
+			mostRecentHeader, err := repo.GetMostRecentHeader()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mostRecentHeader.BlockNumber).To(Equal(header2BlockNumber))
+		})
+
+		It("returns an error if it fails to get the most recent header", func() {
+			_, err := repo.GetMostRecentHeader()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(sql.ErrNoRows))
 		})
 	})
 })

--- a/pkg/datastore/repository.go
+++ b/pkg/datastore/repository.go
@@ -43,6 +43,7 @@ type HeaderRepository interface {
 	GetHeader(blockNumber int64) (core.Header, error)
 	GetHeadersInRange(startingBlock, endingBlock int64) ([]core.Header, error)
 	MissingBlockNumbers(startingBlockNumber, endingBlockNumber int64) ([]int64, error)
+    GetMostRecentHeader() (core.Header, error)
 }
 
 type EventLogRepository interface {

--- a/pkg/datastore/repository.go
+++ b/pkg/datastore/repository.go
@@ -43,7 +43,7 @@ type HeaderRepository interface {
 	GetHeader(blockNumber int64) (core.Header, error)
 	GetHeadersInRange(startingBlock, endingBlock int64) ([]core.Header, error)
 	MissingBlockNumbers(startingBlockNumber, endingBlockNumber int64) ([]int64, error)
-    GetMostRecentHeader() (core.Header, error)
+	GetMostRecentHeader() (core.Header, error)
 }
 
 type EventLogRepository interface {

--- a/pkg/datastore/repository.go
+++ b/pkg/datastore/repository.go
@@ -43,7 +43,7 @@ type HeaderRepository interface {
 	GetHeader(blockNumber int64) (core.Header, error)
 	GetHeadersInRange(startingBlock, endingBlock int64) ([]core.Header, error)
 	MissingBlockNumbers(startingBlockNumber, endingBlockNumber int64) ([]int64, error)
-	GetMostRecentHeader() (core.Header, error)
+	GetMostRecentHeaderBlockNumber() (int64, error)
 }
 
 type EventLogRepository interface {

--- a/pkg/fakes/mock_header_repository.go
+++ b/pkg/fakes/mock_header_repository.go
@@ -37,6 +37,8 @@ type MockHeaderRepository struct {
 	GetHeaderPassedBlockNumber             int64
 	GetHeadersInRangeStartingBlock         int64
 	GetHeadersInRangeEndingBlock           int64
+	MostRecentHeader                       core.Header
+	MostRecentHeaderErr                    error
 }
 
 func NewMockHeaderRepository() *MockHeaderRepository {
@@ -85,7 +87,12 @@ func (repository *MockHeaderRepository) MissingBlockNumbers(startingBlockNumber,
 	return repository.missingBlockNumbers, nil
 }
 
+func (repository *MockHeaderRepository) GetMostRecentHeader() (core.Header, error) {
+	return repository.MostRecentHeader, repository.MostRecentHeaderErr
+}
+
 func (repository *MockHeaderRepository) AssertCreateOrUpdateHeaderCallCountAndPassedBlockNumbers(times int, blockNumbers []int64) {
 	Expect(repository.createOrUpdateHeaderCallCount).To(Equal(times))
 	Expect(repository.createOrUpdateHeaderPassedBlockNumbers).To(Equal(blockNumbers))
 }
+

--- a/pkg/fakes/mock_header_repository.go
+++ b/pkg/fakes/mock_header_repository.go
@@ -37,8 +37,8 @@ type MockHeaderRepository struct {
 	GetHeaderPassedBlockNumber             int64
 	GetHeadersInRangeStartingBlock         int64
 	GetHeadersInRangeEndingBlock           int64
-	MostRecentHeader                       core.Header
-	MostRecentHeaderErr                    error
+	MostRecentHeaderBlockNumber            int64
+	MostRecentHeaderBlockNumberErr         error
 }
 
 func NewMockHeaderRepository() *MockHeaderRepository {
@@ -87,8 +87,8 @@ func (repository *MockHeaderRepository) MissingBlockNumbers(startingBlockNumber,
 	return repository.missingBlockNumbers, nil
 }
 
-func (repository *MockHeaderRepository) GetMostRecentHeader() (core.Header, error) {
-	return repository.MostRecentHeader, repository.MostRecentHeaderErr
+func (repository *MockHeaderRepository) GetMostRecentHeaderBlockNumber() (int64, error) {
+	return repository.MostRecentHeaderBlockNumber, repository.MostRecentHeaderBlockNumberErr
 }
 
 func (repository *MockHeaderRepository) AssertCreateOrUpdateHeaderCallCountAndPassedBlockNumbers(times int, blockNumbers []int64) {

--- a/pkg/fakes/mock_header_repository.go
+++ b/pkg/fakes/mock_header_repository.go
@@ -95,4 +95,3 @@ func (repository *MockHeaderRepository) AssertCreateOrUpdateHeaderCallCountAndPa
 	Expect(repository.createOrUpdateHeaderCallCount).To(Equal(times))
 	Expect(repository.createOrUpdateHeaderPassedBlockNumbers).To(Equal(blockNumbers))
 }
-


### PR DESCRIPTION
Proof of concept that this approach will work for not returning diffs from `GetNewDiffs` if they're from blocks that are "old". Randomly chose the threshold of "old" to be from blocks that are greater than 500 back from the most recent header we have in the system, but totally happy to rethink this/do some more digging into a more appropriate threshold. 

-  [x] need to update the `execute` dockerfile to use this flag: https://github.com/makerdao/vdb-mcd-transformers/pull/184