### PR TITLE
(VDB-1061) Discard diffs from uncles

### DIFF
--- a/db/migrations/20200430103648_add_non_canonical_column_to_storage_diff.sql
+++ b/db/migrations/20200430103648_add_non_canonical_column_to_storage_diff.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE public.storage_diff
+    ADD COLUMN non_canonical BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- +goose Down
+ALTER TABLE public.storage_diff
+    DROP COLUMN non_canonical;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -383,7 +383,8 @@ CREATE TABLE public.storage_diff (
     storage_key bytea,
     storage_value bytea,
     checked boolean DEFAULT false NOT NULL,
-    from_backfill boolean DEFAULT false NOT NULL
+    from_backfill boolean DEFAULT false NOT NULL,
+    non_canonical boolean DEFAULT false NOT NULL
 );
 
 

--- a/libraries/shared/mocks/storage_diff_repository.go
+++ b/libraries/shared/mocks/storage_diff_repository.go
@@ -32,6 +32,7 @@ type MockStorageDiffRepository struct {
 	GetFirstDiffIDToReturn                     int64
 	GetFirstDiffIDErr                          error
 	GetFirstDiffBlockHeightPassed              int64
+	MarkNonCanonicalPassedID                   int64
 }
 
 func (repository *MockStorageDiffRepository) CreateStorageDiff(rawDiff types.RawDiff) (int64, error) {
@@ -62,4 +63,9 @@ func (repository *MockStorageDiffRepository) MarkChecked(id int64) error {
 func (repository *MockStorageDiffRepository) GetFirstDiffIDForBlockHeight(blockHeight int64) (int64, error) {
 	repository.GetFirstDiffBlockHeightPassed = blockHeight
 	return repository.GetFirstDiffIDToReturn, repository.GetFirstDiffIDErr
+}
+
+func (repository *MockStorageDiffRepository) MarkNonCanonical(id int64) error {
+	repository.MarkNonCanonicalPassedID = id
+	return nil
 }

--- a/libraries/shared/storage/types/diff.go
+++ b/libraries/shared/storage/types/diff.go
@@ -37,10 +37,11 @@ type RawDiff struct {
 
 type PersistedDiff struct {
 	RawDiff
-	Checked      bool
-	FromBackfill bool `db:"from_backfill"`
 	ID           int64
 	HeaderID     int64 `db:"header_id"`
+	Checked      bool
+	NonCanonical bool `db:"non_canonical"`
+	FromBackfill bool `db:"from_backfill"`
 }
 
 func FromParityCsvRow(csvRow []string) (RawDiff, error) {


### PR DESCRIPTION
- mark diff as non-canonical if block_hash doesn't match corresponding records in public.headers and block height is > 250 back from the head of the chain (deduced via max block_height in public.storage_diff)
- don't return non-canonical diffs in future lookups for unchecked diffs
- also a bit of refactoring to enable using errors.Is(x, y) instead of reflection when we want to handle specific errors

Note: will require corresponding PR to add migration to vdb-mcd-transformers. Postponing that until after some review so that I don't have to update the timestamp in two places