### PR TITLE
Hash storage key for diffs from new geth patch

### DIFF
--- a/libraries/shared/storage/fetcher/geth_rpc_storage_fetcher_test.go
+++ b/libraries/shared/storage/fetcher/geth_rpc_storage_fetcher_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Geth RPC Storage Fetcher", func() {
 			close(done)
 		})
 
-		It("adds parsed statediff payloads to the out channel for the old geth patch", func(done Done) {
+		It("adds parsed statediff payloads to the out channel for the new geth patch", func(done Done) {
 			streamer.SetPayloads([]statediff.Payload{test_data.MockStatediffPayload})
 
 			go statediffFetcher.FetchStorageDiffs(storagediffChan, errorChan)
@@ -223,21 +223,21 @@ var _ = Describe("Geth RPC Storage Fetcher", func() {
 				HashedAddress: crypto.Keccak256Hash(test_data.ContractLeafKey[:]),
 				BlockHash:     common.HexToHash("0xfa40fbe2d98d98b3363a778d52f2bcd29d6790b9b3f3cab2b167fd12d3550f73"),
 				BlockHeight:   intHeight,
-				StorageKey:    common.BytesToHash(test_data.StorageKey),
+				StorageKey:    crypto.Keccak256Hash(test_data.StorageKey),
 				StorageValue:  common.BytesToHash(test_data.SmallStorageValue),
 			}
 			expectedDiff2 := types.RawDiff{
 				HashedAddress: crypto.Keccak256Hash(test_data.AnotherContractLeafKey[:]),
 				BlockHash:     common.HexToHash("0xfa40fbe2d98d98b3363a778d52f2bcd29d6790b9b3f3cab2b167fd12d3550f73"),
 				BlockHeight:   intHeight,
-				StorageKey:    common.BytesToHash(test_data.StorageKey),
+				StorageKey:    crypto.Keccak256Hash(test_data.StorageKey),
 				StorageValue:  common.BytesToHash(test_data.LargeStorageValue),
 			}
 			expectedDiff3 := types.RawDiff{
 				HashedAddress: crypto.Keccak256Hash(test_data.AnotherContractLeafKey[:]),
 				BlockHash:     common.HexToHash("0xfa40fbe2d98d98b3363a778d52f2bcd29d6790b9b3f3cab2b167fd12d3550f73"),
 				BlockHeight:   intHeight,
-				StorageKey:    common.BytesToHash(test_data.StorageKey),
+				StorageKey:    crypto.Keccak256Hash(test_data.StorageKey),
 				StorageValue:  common.BytesToHash(test_data.SmallStorageValue),
 			}
 

--- a/libraries/shared/storage/types/diff.go
+++ b/libraries/shared/storage/types/diff.go
@@ -87,7 +87,7 @@ func FromNewGethStateDiff(account statediff.AccountDiff, stateDiff *statediff.St
 		HashedAddress: crypto.Keccak256Hash(account.Key),
 		BlockHash:     stateDiff.BlockHash,
 		BlockHeight:   int(stateDiff.BlockNumber.Int64()),
-		StorageKey:    common.BytesToHash(storage.Key),
+		StorageKey:    crypto.Keccak256Hash(storage.Key),
 		StorageValue:  common.BytesToHash(decodedRLPStorageValue),
 	}, nil
 }

--- a/libraries/shared/storage/types/diff_test.go
+++ b/libraries/shared/storage/types/diff_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Storage row parsing", func() {
 			Expect(result.BlockHash).To(Equal(fakes.FakeHash))
 			expectedBlockHeight := int(stateDiff.BlockNumber.Int64())
 			Expect(result.BlockHeight).To(Equal(expectedBlockHeight))
-			expectedStorageKey := common.BytesToHash(storageDiff.Key)
+			expectedStorageKey := crypto.Keccak256Hash(storageDiff.Key)
 			Expect(result.StorageKey).To(Equal(expectedStorageKey))
 			expectedStorageValue := common.BytesToHash(storageValueBytes)
 			Expect(result.StorageValue).To(Equal(expectedStorageValue))


### PR DESCRIPTION
- Ensure we hit uniqueness constraint violation and do nothing if
  inserting a duplicate diff