### PR TITLE
(VDB-1119) Minimize disruption when adding new event transformer

### DIFF
--- a/libraries/shared/logs/extractor.go
+++ b/libraries/shared/logs/extractor.go
@@ -179,10 +179,7 @@ func (extractor *LogExtractor) updateCheckedHeaders(config event.TransformerConf
 		return watchingLogErr
 	}
 	if !alreadyWatchingLog {
-		uncheckHeadersErr := extractor.CheckedHeadersRepository.MarkHeadersUncheckedSince(config.StartingBlockNumber)
-		if uncheckHeadersErr != nil {
-			return uncheckHeadersErr
-		}
+		logrus.Warnf("new event log for topic 0 %s detected, back-fill may be required for already-checked headers", config.Topic)
 		markLogWatchedErr := extractor.CheckedLogsRepository.MarkLogWatched(config.ContractAddresses, config.Topic)
 		if markLogWatchedErr != nil {
 			return markLogWatchedErr

--- a/libraries/shared/logs/extractor_test.go
+++ b/libraries/shared/logs/extractor_test.go
@@ -130,42 +130,12 @@ var _ = Describe("Log extractor", func() {
 			Expect(err).To(MatchError(fakes.FakeError))
 		})
 
-		Describe("when log has previously been checked", func() {
-			It("does not mark any headers unchecked", func() {
-				checkedLogsRepository.AlreadyWatchingLogReturn = true
-
-				err := extractor.AddTransformerConfig(getTransformerConfig(rand.Int63(), defaultEndingBlockNumber))
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(checkedHeadersRepository.MarkHeadersUncheckedCalled).To(BeFalse())
-			})
-		})
-
 		Describe("when log has not previously been checked", func() {
 			BeforeEach(func() {
 				checkedLogsRepository.AlreadyWatchingLogReturn = false
 			})
 
-			It("marks headers since transformer's starting block number as unchecked", func() {
-				blockNumber := rand.Int63()
-
-				err := extractor.AddTransformerConfig(getTransformerConfig(blockNumber, defaultEndingBlockNumber))
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(checkedHeadersRepository.MarkHeadersUncheckedCalled).To(BeTrue())
-				Expect(checkedHeadersRepository.MarkHeadersUncheckedStartingBlockNumber).To(Equal(blockNumber))
-			})
-
-			It("returns error if marking headers unchecked returns error", func() {
-				checkedHeadersRepository.MarkHeadersUncheckedReturnError = fakes.FakeError
-
-				err := extractor.AddTransformerConfig(getTransformerConfig(rand.Int63(), defaultEndingBlockNumber))
-
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(fakes.FakeError))
-			})
-
-			It("persists that tranformer's log has been checked", func() {
+			It("persists that tranformer's log is watched", func() {
 				config := getTransformerConfig(rand.Int63(), defaultEndingBlockNumber)
 
 				err := extractor.AddTransformerConfig(config)
@@ -175,7 +145,7 @@ var _ = Describe("Log extractor", func() {
 				Expect(checkedLogsRepository.MarkLogWatchedTopicZero).To(Equal(config.Topic))
 			})
 
-			It("returns error if marking logs checked returns error", func() {
+			It("returns error if marking logs watched returns error", func() {
 				checkedLogsRepository.MarkLogWatchedError = fakes.FakeError
 
 				err := extractor.AddTransformerConfig(getTransformerConfig(rand.Int63(), defaultEndingBlockNumber))

--- a/pkg/datastore/postgres/repositories/checked_headers_repository.go
+++ b/pkg/datastore/postgres/repositories/checked_headers_repository.go
@@ -39,12 +39,6 @@ func (repo CheckedHeadersRepository) MarkHeaderChecked(headerID int64) error {
 	return err
 }
 
-// Zero out check count for headers with block number >= startingBlockNumber
-func (repo CheckedHeadersRepository) MarkHeadersUncheckedSince(startingBlockNumber int64) error {
-	_, err := repo.db.Exec(`UPDATE public.headers SET check_count = 0 WHERE block_number >= $1`, startingBlockNumber)
-	return err
-}
-
 // Zero out check count for header with the given block number
 func (repo CheckedHeadersRepository) MarkSingleHeaderUnchecked(blockNumber int64) error {
 	_, err := repo.db.Exec(`UPDATE public.headers SET check_count = 0 WHERE block_number = $1`, blockNumber)

--- a/pkg/datastore/postgres/repositories/checked_headers_repository_test.go
+++ b/pkg/datastore/postgres/repositories/checked_headers_repository_test.go
@@ -72,47 +72,6 @@ var _ = Describe("Checked Headers repository", func() {
 		})
 	})
 
-	Describe("MarkHeadersUncheckedSince", func() {
-		It("marks headers with matching block number as unchecked", func() {
-			blockNumberOne := rand.Int63()
-			blockNumberTwo := blockNumberOne + 1
-			blockNumberThree := blockNumberOne + 2
-			fakeHeaderOne := fakes.GetFakeHeader(blockNumberOne)
-			fakeHeaderTwo := fakes.GetFakeHeader(blockNumberTwo)
-			fakeHeaderThree := fakes.GetFakeHeader(blockNumberThree)
-			headerRepository := repositories.NewHeaderRepository(db)
-			// insert three headers with incrementing block number
-			headerIdOne, insertHeaderOneErr := headerRepository.CreateOrUpdateHeader(fakeHeaderOne)
-			Expect(insertHeaderOneErr).NotTo(HaveOccurred())
-			headerIdTwo, insertHeaderTwoErr := headerRepository.CreateOrUpdateHeader(fakeHeaderTwo)
-			Expect(insertHeaderTwoErr).NotTo(HaveOccurred())
-			headerIdThree, insertHeaderThreeErr := headerRepository.CreateOrUpdateHeader(fakeHeaderThree)
-			Expect(insertHeaderThreeErr).NotTo(HaveOccurred())
-			// mark all headers checked
-			markHeaderOneCheckedErr := repo.MarkHeaderChecked(headerIdOne)
-			Expect(markHeaderOneCheckedErr).NotTo(HaveOccurred())
-			markHeaderTwoCheckedErr := repo.MarkHeaderChecked(headerIdTwo)
-			Expect(markHeaderTwoCheckedErr).NotTo(HaveOccurred())
-			markHeaderThreeCheckedErr := repo.MarkHeaderChecked(headerIdThree)
-			Expect(markHeaderThreeCheckedErr).NotTo(HaveOccurred())
-
-			// mark headers unchecked since blockNumberTwo
-			err := repo.MarkHeadersUncheckedSince(blockNumberTwo)
-
-			Expect(err).NotTo(HaveOccurred())
-			var headerOneCheckCount, headerTwoCheckCount, headerThreeCheckCount int
-			getHeaderOneErr := db.Get(&headerOneCheckCount, `SELECT check_count FROM public.headers WHERE id = $1`, headerIdOne)
-			Expect(getHeaderOneErr).NotTo(HaveOccurred())
-			Expect(headerOneCheckCount).To(Equal(1))
-			getHeaderTwoErr := db.Get(&headerTwoCheckCount, `SELECT check_count FROM public.headers WHERE id = $1`, headerIdTwo)
-			Expect(getHeaderTwoErr).NotTo(HaveOccurred())
-			Expect(headerTwoCheckCount).To(BeZero())
-			getHeaderThreeErr := db.Get(&headerThreeCheckCount, `SELECT check_count FROM public.headers WHERE id = $1`, headerIdThree)
-			Expect(getHeaderThreeErr).NotTo(HaveOccurred())
-			Expect(headerThreeCheckCount).To(BeZero())
-		})
-	})
-
 	Describe("MarkSingleHeaderUnchecked", func() {
 		It("marks headers with matching block number as unchecked", func() {
 			blockNumberOne := rand.Int63()

--- a/pkg/datastore/repository.go
+++ b/pkg/datastore/repository.go
@@ -27,7 +27,6 @@ type AddressRepository interface {
 
 type CheckedHeadersRepository interface {
 	MarkHeaderChecked(headerID int64) error
-	MarkHeadersUncheckedSince(startingBlockNumber int64) error
 	MarkSingleHeaderUnchecked(blockNumber int64) error
 	UncheckedHeaders(startingBlockNumber, endingBlockNumber, checkCount int64) ([]core.Header, error)
 }

--- a/pkg/fakes/mock_checked_headers_repository.go
+++ b/pkg/fakes/mock_checked_headers_repository.go
@@ -21,26 +21,17 @@ import (
 )
 
 type MockCheckedHeadersRepository struct {
-	MarkHeaderCheckedHeaderID               int64
-	MarkHeaderCheckedReturnError            error
-	MarkHeadersUncheckedCalled              bool
-	MarkHeadersUncheckedReturnError         error
-	MarkHeadersUncheckedStartingBlockNumber int64
-	UncheckedHeadersCheckCount              int64
-	UncheckedHeadersEndingBlockNumber       int64
-	UncheckedHeadersReturnError             error
-	UncheckedHeadersReturnHeaders           []core.Header
-	UncheckedHeadersStartingBlockNumber     int64
+	MarkHeaderCheckedHeaderID           int64
+	MarkHeaderCheckedReturnError        error
+	UncheckedHeadersCheckCount          int64
+	UncheckedHeadersEndingBlockNumber   int64
+	UncheckedHeadersReturnError         error
+	UncheckedHeadersReturnHeaders       []core.Header
+	UncheckedHeadersStartingBlockNumber int64
 }
 
 func (repository *MockCheckedHeadersRepository) MarkSingleHeaderUnchecked(blockNumber int64) error {
 	panic("implement me")
-}
-
-func (repository *MockCheckedHeadersRepository) MarkHeadersUncheckedSince(startingBlockNumber int64) error {
-	repository.MarkHeadersUncheckedCalled = true
-	repository.MarkHeadersUncheckedStartingBlockNumber = startingBlockNumber
-	return repository.MarkHeadersUncheckedReturnError
 }
 
 func (repository *MockCheckedHeadersRepository) MarkHeaderChecked(headerID int64) error {


### PR DESCRIPTION
- Don't mark previous headers unchecked
- Requires new work to backfill events from already checked headers

NOTE: this PR only removes the disruption, but at the cost of not automatically back-filling events from already checked headers. Will need a new command or goroutine within `execute` to handle that