### PR TITLE
Dont pretty print json for cloudwatch

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,9 +9,7 @@ import (
 )
 
 func main() {
-	log.SetFormatter(&log.JSONFormatter{
-		PrettyPrint: true,
-	})
+	log.SetFormatter(&log.JSONFormatter{})
 	file, err := os.OpenFile("vulcanizedb.log",
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err == nil {


### PR DESCRIPTION
This screws up the JSON support in Cloudwatch - we need JSON one per line.

**Before**
{
  "SubCommand": "headerSync",
  "level": "fatal",
  "msg": "dial unix: missing address",
  "time": "2020-05-19T15:28:04-05:00"
}
**After**

{"level":"info","msg":"----- Starting vDB -----","time":"2020-05-19T15:28:47-05:00"}
{"level":"warning","msg":"No config file passed with --config flag; attempting to use env vars","time":"2020-05-19T15:28:47-05:00"}
{"level":"info","msg":"Log level set to info","time":"2020-05-19T15:28:47-05:00"}
{"SubCommand":"headerSync","level":"fatal","msg":"dial unix: missing address","time":"2020-05-19T15:28:47-05:00"}
{"level":"info","msg":"----- Starting vDB -----","time":"2020-05-19T15:29:57-05:00"}
{"level":"warning","msg":"No config file passed with --config flag; attempting to use env vars","time":"2020-05-19T15:29:57-05:00"}
{"level":"info","msg":"Log level set to info","time":"2020-05-19T15:29:57-05:00"}
{"SubCommand":"headerSync","level":"fatal","msg":"dial unix: missing address","time":"2020-05-19T15:29:57-05:00"}