### PR TITLE
Update travis to go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: go
 go:
-- 1.13
+- 1.14
 services:
 - postgresql
 - docker


### PR DESCRIPTION
- match version being used to build images