### PR TITLE
(VDB-1350) Write health check on watcher.Execute

### DIFF
--- a/libraries/shared/watcher/event_watcher.go
+++ b/libraries/shared/watcher/event_watcher.go
@@ -19,7 +19,6 @@ package watcher
 import (
 	"fmt"
 	"io"
-	"os"
 	"time"
 
 	"github.com/makerdao/vulcanizedb/libraries/shared/constants"
@@ -134,25 +133,6 @@ func (watcher *EventWatcher) withRetry(call func() error, expectedErrors []error
 			}
 		}
 	}
-}
-
-func addStatusForHealthCheck(msg []byte) error {
-	healthCheckFile, openErr := os.OpenFile(HealthCheckFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if openErr != nil {
-		return fmt.Errorf("error opening %s: %w", HealthCheckFile, openErr)
-	}
-	if _, writeErr := healthCheckFile.Write(msg); writeErr != nil {
-		closeErr := healthCheckFile.Close()
-		if closeErr != nil {
-			errorMsg := "error closing %s: %w -  after error writing: %s"
-			return fmt.Errorf(errorMsg, HealthCheckFile, closeErr, writeErr.Error())
-		}
-		return fmt.Errorf("error writing storage watched startup to %s: %w", HealthCheckFile, writeErr)
-	}
-	if closeErr := healthCheckFile.Close(); closeErr != nil {
-		return fmt.Errorf("error closing %s: %w", HealthCheckFile, closeErr)
-	}
-	return nil
 }
 
 func isUnexpectedError(currentError error, expectedErrors []error) bool {

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -69,6 +69,11 @@ func (watcher StorageWatcher) AddTransformers(initializers []storage2.Transforme
 }
 
 func (watcher StorageWatcher) Execute() error {
+	healthCheckErr := addStatusForHealthCheck([]byte("storage watcher starting\n"))
+	if healthCheckErr != nil {
+		return fmt.Errorf("error confirming health check: %w", healthCheckErr)
+	}
+
 	for {
 		err := watcher.transformDiffs()
 		if err != nil {

--- a/libraries/shared/watcher/utils.go
+++ b/libraries/shared/watcher/utils.go
@@ -1,0 +1,25 @@
+package watcher
+
+import (
+	"fmt"
+	"os"
+)
+
+func addStatusForHealthCheck(msg []byte) error {
+	healthCheckFile, openErr := os.OpenFile(HealthCheckFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if openErr != nil {
+		return fmt.Errorf("error opening %s: %w", HealthCheckFile, openErr)
+	}
+	if _, writeErr := healthCheckFile.Write(msg); writeErr != nil {
+		closeErr := healthCheckFile.Close()
+		if closeErr != nil {
+			errorMsg := "error closing %s: %w -  after error writing: %s"
+			return fmt.Errorf(errorMsg, HealthCheckFile, closeErr, writeErr.Error())
+		}
+		return fmt.Errorf("error writing watcher startup to %s: %w", HealthCheckFile, writeErr)
+	}
+	if closeErr := healthCheckFile.Close(); closeErr != nil {
+		return fmt.Errorf("error closing %s: %w", HealthCheckFile, closeErr)
+	}
+	return nil
+}


### PR DESCRIPTION
- enables health check to verify Execute has been invoked
- only applied to storage/event watchers now, since contract watcher
  is less commonly used