### PR TITLE
(VDB-1363) backfill events

### DIFF
--- a/cmd/backfillEvents.go
+++ b/cmd/backfillEvents.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/makerdao/vulcanizedb/libraries/shared/logs"
+	"github.com/makerdao/vulcanizedb/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// backfillEventsCmd represents the backfillEvents command
+var backfillEventsCmd = &cobra.Command{
+	Use:   "backfillEvents",
+	Short: "BackFill events from already-checked headers",
+	Long: `Fetch and persist events from configured transformers across a range
+of headers that may have already been checked for logs. Useful when adding a
+new event transformer to an instance that has already been running and marking
+headers checked as it queried for the previous (now incomplete) set of logs.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := backFillEvents()
+		if err != nil {
+			logrus.Fatalf("error back-filling events: %s", err.Error())
+		}
+		logrus.Info("completed back-filling events")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(backfillEventsCmd)
+}
+
+func backFillEvents() error {
+	ethEventInitializers, _, _, exportTransformersErr := exportTransformers()
+	if exportTransformersErr != nil {
+		LogWithCommand.Fatalf("SubCommand %v: exporting transformers failed: %v", SubCommand, exportTransformersErr)
+	}
+
+	blockChain := getBlockChain()
+	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
+
+	extractor := logs.NewLogExtractor(&db, blockChain)
+
+	for _, initializer := range ethEventInitializers {
+		transformer := initializer(&db)
+		err := extractor.AddTransformerConfig(transformer.GetConfig())
+		if err != nil {
+			return fmt.Errorf("error adding transformer: %w", err)
+		}
+	}
+
+	err := extractor.BackFillLogs()
+	if err != nil {
+		return fmt.Errorf("error backfilling logs: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/backfillEvents.go
+++ b/cmd/backfillEvents.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var endingBlockNumber int64
+
 // backfillEventsCmd represents the backfillEvents command
 var backfillEventsCmd = &cobra.Command{
 	Use:   "backfillEvents",
@@ -18,6 +20,8 @@ of headers that may have already been checked for logs. Useful when adding a
 new event transformer to an instance that has already been running and marking
 headers checked as it queried for the previous (now incomplete) set of logs.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		SubCommand = cmd.CalledAs()
+		LogWithCommand = *logrus.WithField("SubCommand", SubCommand)
 		err := backFillEvents()
 		if err != nil {
 			logrus.Fatalf("error back-filling events: %s", err.Error())
@@ -28,6 +32,8 @@ headers checked as it queried for the previous (now incomplete) set of logs.`,
 
 func init() {
 	rootCmd.AddCommand(backfillEventsCmd)
+	backfillEventsCmd.Flags().Int64VarP(&endingBlockNumber, "ending-block-number", "e", -1, "last block from which to back-fill events")
+	backfillEventsCmd.MarkFlagRequired("ending-block-number")
 }
 
 func backFillEvents() error {
@@ -49,7 +55,7 @@ func backFillEvents() error {
 		}
 	}
 
-	err := extractor.BackFillLogs()
+	err := extractor.BackFillLogs(endingBlockNumber)
 	if err != nil {
 		return fmt.Errorf("error backfilling logs: %w", err)
 	}

--- a/libraries/shared/logs/extractor.go
+++ b/libraries/shared/logs/extractor.go
@@ -39,7 +39,7 @@ var (
 
 type ILogExtractor interface {
 	AddTransformerConfig(config event.TransformerConfig) error
-	BackFillLogs() error
+	BackFillLogs(endingBlock int64) error
 	ExtractLogs(recheckHeaders constants.TransformerExecution) error
 }
 
@@ -146,13 +146,13 @@ func (extractor LogExtractor) ExtractLogs(recheckHeaders constants.TransformerEx
 }
 
 // BackFillLogs fetches and persists watched logs from provided range of headers
-func (extractor LogExtractor) BackFillLogs() error {
+func (extractor LogExtractor) BackFillLogs(endingBlock int64) error {
 	if len(extractor.Addresses) < 1 {
 		logrus.Errorf("error extracting logs: %s", ErrNoWatchedAddresses.Error())
 		return fmt.Errorf("error extracting logs: %w", ErrNoWatchedAddresses)
 	}
 
-	headers, headersErr := extractor.HeaderRepository.GetHeadersInRange(*extractor.StartingBlock, *extractor.EndingBlock)
+	headers, headersErr := extractor.HeaderRepository.GetHeadersInRange(*extractor.StartingBlock, endingBlock)
 	if headersErr != nil {
 		logrus.Errorf("error fetching missing headers: %s", headersErr)
 		return fmt.Errorf("error getting unchecked headers to check for logs: %w", headersErr)

--- a/libraries/shared/logs/extractor_test.go
+++ b/libraries/shared/logs/extractor_test.go
@@ -383,6 +383,149 @@ var _ = Describe("Log extractor", func() {
 			})
 		})
 	})
+
+	Describe("BackFillLogs", func() {
+		It("returns error if no watched addresses configured", func() {
+			err := extractor.BackFillLogs()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(logs.ErrNoWatchedAddresses))
+		})
+
+		It("returns error if getting headers in range returns error", func() {
+			mockHeaderRepository := &fakes.MockHeaderRepository{}
+			mockHeaderRepository.GetHeadersInRangeError = fakes.FakeError
+			extractor.HeaderRepository = mockHeaderRepository
+			addTransformerConfig(extractor)
+
+			err := extractor.BackFillLogs()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fakes.FakeError))
+		})
+
+		It("does nothing if no headers found", func() {
+			mockHeaderRepository := &fakes.MockHeaderRepository{}
+			extractor.HeaderRepository = mockHeaderRepository
+			addTransformerConfig(extractor)
+			mockLogFetcher := &mocks.MockLogFetcher{}
+			extractor.Fetcher = mockLogFetcher
+
+			_ = extractor.BackFillLogs()
+
+			Expect(mockLogFetcher.FetchCalled).To(BeFalse())
+		})
+
+		It("fetches logs for headers in range", func() {
+			addHeaderInRange(extractor)
+			config := event.TransformerConfig{
+				ContractAddresses:   []string{fakes.FakeAddress.Hex()},
+				Topic:               fakes.FakeHash.Hex(),
+				StartingBlockNumber: rand.Int63(),
+			}
+			addTransformerErr := extractor.AddTransformerConfig(config)
+			Expect(addTransformerErr).NotTo(HaveOccurred())
+			mockLogFetcher := &mocks.MockLogFetcher{}
+			extractor.Fetcher = mockLogFetcher
+
+			err := extractor.BackFillLogs()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockLogFetcher.FetchCalled).To(BeTrue())
+			expectedTopics := []common.Hash{common.HexToHash(config.Topic)}
+			Expect(mockLogFetcher.Topics).To(Equal(expectedTopics))
+			expectedAddresses := event.HexStringsToAddresses(config.ContractAddresses)
+			Expect(mockLogFetcher.ContractAddresses).To(Equal(expectedAddresses))
+		})
+
+		It("returns error if fetching logs fails", func() {
+			addHeaderInRange(extractor)
+			addTransformerConfig(extractor)
+			mockLogFetcher := &mocks.MockLogFetcher{}
+			mockLogFetcher.ReturnError = fakes.FakeError
+			extractor.Fetcher = mockLogFetcher
+
+			err := extractor.BackFillLogs()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fakes.FakeError))
+		})
+
+		It("does not sync transactions when no logs", func() {
+			addHeaderInRange(extractor)
+			addTransformerConfig(extractor)
+			mockTransactionSyncer := &fakes.MockTransactionSyncer{}
+			extractor.Syncer = mockTransactionSyncer
+
+			err := extractor.BackFillLogs()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockTransactionSyncer.SyncTransactionsCalled).To(BeFalse())
+		})
+
+		Describe("when there are fetched logs", func() {
+			It("syncs transactions", func() {
+				addHeaderInRange(extractor)
+				addFetchedLog(extractor)
+				addTransformerConfig(extractor)
+				mockTransactionSyncer := &fakes.MockTransactionSyncer{}
+				extractor.Syncer = mockTransactionSyncer
+
+				err := extractor.BackFillLogs()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mockTransactionSyncer.SyncTransactionsCalled).To(BeTrue())
+			})
+
+			It("returns error if syncing transactions fails", func() {
+				addHeaderInRange(extractor)
+				addFetchedLog(extractor)
+				addTransformerConfig(extractor)
+				mockTransactionSyncer := &fakes.MockTransactionSyncer{}
+				mockTransactionSyncer.SyncTransactionsError = fakes.FakeError
+				extractor.Syncer = mockTransactionSyncer
+
+				err := extractor.BackFillLogs()
+
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(fakes.FakeError))
+			})
+
+			It("persists fetched logs", func() {
+				addHeaderInRange(extractor)
+				addTransformerConfig(extractor)
+				fakeLogs := []types.Log{{
+					Address: common.HexToAddress("0xA"),
+					Topics:  []common.Hash{common.HexToHash("0xA")},
+					Data:    []byte{},
+					Index:   0,
+				}}
+				mockLogFetcher := &mocks.MockLogFetcher{ReturnLogs: fakeLogs}
+				extractor.Fetcher = mockLogFetcher
+				mockLogRepository := &fakes.MockEventLogRepository{}
+				extractor.LogRepository = mockLogRepository
+
+				err := extractor.BackFillLogs()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mockLogRepository.PassedLogs).To(Equal(fakeLogs))
+			})
+
+			It("returns error if persisting logs fails", func() {
+				addHeaderInRange(extractor)
+				addFetchedLog(extractor)
+				addTransformerConfig(extractor)
+				mockLogRepository := &fakes.MockEventLogRepository{}
+				mockLogRepository.CreateError = fakes.FakeError
+				extractor.LogRepository = mockLogRepository
+
+				err := extractor.BackFillLogs()
+
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(fakes.FakeError))
+			})
+		})
+	})
 })
 
 func addTransformerConfig(extractor *logs.LogExtractor) {
@@ -398,6 +541,12 @@ func addUncheckedHeader(extractor *logs.LogExtractor) {
 	mockCheckedHeadersRepository := &fakes.MockCheckedHeadersRepository{}
 	mockCheckedHeadersRepository.UncheckedHeadersReturnHeaders = []core.Header{{}}
 	extractor.CheckedHeadersRepository = mockCheckedHeadersRepository
+}
+
+func addHeaderInRange(extractor *logs.LogExtractor) {
+	mockHeadersRepository := &fakes.MockHeaderRepository{}
+	mockHeadersRepository.AllHeaders = []core.Header{{}}
+	extractor.HeaderRepository = mockHeadersRepository
 }
 
 func addFetchedLog(extractor *logs.LogExtractor) {

--- a/libraries/shared/mocks/log_extractor.go
+++ b/libraries/shared/mocks/log_extractor.go
@@ -48,3 +48,7 @@ func (extractor *MockLogExtractor) ExtractLogs(recheckHeaders constants.Transfor
 	// return no unchecked headers error so that extractor hits retry interval when delegator under test
 	return logs.ErrNoUncheckedHeaders
 }
+
+func (extractor *MockLogExtractor) BackFillLogs() error {
+	panic("implement me")
+}

--- a/libraries/shared/mocks/log_extractor.go
+++ b/libraries/shared/mocks/log_extractor.go
@@ -49,6 +49,6 @@ func (extractor *MockLogExtractor) ExtractLogs(recheckHeaders constants.Transfor
 	return logs.ErrNoUncheckedHeaders
 }
 
-func (extractor *MockLogExtractor) BackFillLogs() error {
+func (extractor *MockLogExtractor) BackFillLogs(endingBlock int64) error {
 	panic("implement me")
 }

--- a/libraries/shared/storage/backfill/storage_value_loader_test.go
+++ b/libraries/shared/storage/backfill/storage_value_loader_test.go
@@ -128,7 +128,7 @@ var _ = Describe("StorageValueLoader", func() {
 	})
 
 	It("returns an error if a header for the given block cannot be retrieved", func() {
-		headerRepo.GetHeaderByBlockNumberError = fakes.FakeError
+		headerRepo.GetHeadersInRangeError = fakes.FakeError
 		runnerErr := runner.Run()
 		Expect(runnerErr).To(HaveOccurred())
 		Expect(runnerErr).To(Equal(fakes.FakeError))

--- a/pkg/fakes/mock_header_repository.go
+++ b/pkg/fakes/mock_header_repository.go
@@ -23,10 +23,6 @@ import (
 )
 
 type MockHeaderRepository struct {
-	createOrUpdateHeaderCallCount          int
-	createOrUpdateHeaderErr                error
-	createOrUpdateHeaderPassedBlockNumbers []int64
-	createOrUpdateHeaderReturnID           int64
 	AllHeaders                             []core.Header
 	CreateTransactionsCalled               bool
 	CreateTransactionsError                error
@@ -35,13 +31,18 @@ type MockHeaderRepository struct {
 	GetHeaderByBlockNumberReturnID         int64
 	GetHeaderByIDError                     error
 	GetHeaderByIDHeaderToReturn            core.Header
-	missingBlockNumbers                    []int64
-	headerExists                           bool
 	GetHeaderPassedBlockNumber             int64
-	GetHeadersInRangeStartingBlock         int64
 	GetHeadersInRangeEndingBlock           int64
+	GetHeadersInRangeError                 error
+	GetHeadersInRangeStartingBlock         int64
 	MostRecentHeaderBlockNumber            int64
 	MostRecentHeaderBlockNumberErr         error
+	createOrUpdateHeaderCallCount          int
+	createOrUpdateHeaderErr                error
+	createOrUpdateHeaderPassedBlockNumbers []int64
+	createOrUpdateHeaderReturnID           int64
+	headerExists                           bool
+	missingBlockNumbers                    []int64
 }
 
 func NewMockHeaderRepository() *MockHeaderRepository {
@@ -91,7 +92,7 @@ func (mock *MockHeaderRepository) GetHeaderByID(id int64) (core.Header, error) {
 func (mock *MockHeaderRepository) GetHeadersInRange(startingBlock, endingBlock int64) ([]core.Header, error) {
 	mock.GetHeadersInRangeStartingBlock = startingBlock
 	mock.GetHeadersInRangeEndingBlock = endingBlock
-	return mock.AllHeaders, mock.GetHeaderByBlockNumberError
+	return mock.AllHeaders, mock.GetHeadersInRangeError
 }
 
 func (mock *MockHeaderRepository) MissingBlockNumbers(startingBlockNumber, endingBlockNumber int64) ([]int64, error) {


### PR DESCRIPTION
Pretty tempted to remove the ending block number from the transformer config since we generally don't use it and _can't_ use it here without messing up `execute` (if we modify the individual transformers' configs, it'll affect both images). Held off to avoid expanding the diff but may plan to add that and/or open up a separate PR after this. Also it seems like some of the naming in `libraries/shared/factories/event` could use some improvement after we removed the `converter` awhile back