### PR TITLE
[WIP] (VDB-1336) avoid duplicate header inserts

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,7 +57,7 @@ var (
 
 const (
 	pollingInterval  = 7 * time.Second
-	validationWindow = 15
+	validationWindow = 25
 )
 
 var rootCmd = &cobra.Command{

--- a/db/migrations/20200622155011_update_get_or_create_header_function.sql
+++ b/db/migrations/20200622155011_update_get_or_create_header_function.sql
@@ -1,0 +1,94 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.get_or_create_header(block_number BIGINT, hash VARCHAR(66), raw JSONB,
+                                                       block_timestamp NUMERIC, eth_node_id INTEGER) RETURNS INTEGER AS
+$$
+DECLARE
+    matching_header_id    INTEGER := (
+        SELECT id
+        FROM public.headers
+        WHERE headers.block_number = get_or_create_header.block_number
+          AND headers.hash = get_or_create_header.hash
+    );
+    nonmatching_header_id INTEGER := (
+        SELECT id
+        FROM public.headers
+        WHERE headers.block_number = get_or_create_header.block_number
+          AND headers.hash != get_or_create_header.hash
+    );
+    max_block_number      BIGINT  := (
+        SELECT MAX(headers.block_number)
+        FROM public.headers
+    );
+    inserted_header_id    INTEGER;
+BEGIN
+    IF matching_header_id != 0 THEN
+        RETURN matching_header_id;
+    END IF;
+
+    IF nonmatching_header_id != 0 AND block_number <= max_block_number - 15 THEN
+        RETURN nonmatching_header_id;
+    END IF;
+
+    IF nonmatching_header_id != 0 AND block_number > max_block_number - 15 THEN
+        DELETE FROM public.headers WHERE id = nonmatching_header_id;
+    END IF;
+
+    INSERT INTO public.headers (hash, block_number, raw, block_timestamp, eth_node_id)
+    VALUES (get_or_create_header.hash, get_or_create_header.block_number, get_or_create_header.raw,
+            get_or_create_header.block_timestamp, get_or_create_header.eth_node_id)
+    ON CONFLICT DO NOTHING
+    RETURNING id INTO inserted_header_id;
+
+    RETURN inserted_header_id;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.get_or_create_header(block_number BIGINT, hash VARCHAR(66), raw JSONB,
+                                                       block_timestamp NUMERIC, eth_node_id INTEGER) RETURNS INTEGER AS
+$$
+DECLARE
+    matching_header_id    INTEGER := (
+        SELECT id
+        FROM public.headers
+        WHERE headers.block_number = get_or_create_header.block_number
+          AND headers.hash = get_or_create_header.hash
+    );
+    nonmatching_header_id INTEGER := (
+        SELECT id
+        FROM public.headers
+        WHERE headers.block_number = get_or_create_header.block_number
+          AND headers.hash != get_or_create_header.hash
+    );
+    max_block_number      BIGINT  := (
+        SELECT MAX(headers.block_number)
+        FROM public.headers
+    );
+    inserted_header_id    INTEGER;
+BEGIN
+    IF matching_header_id != 0 THEN
+        RETURN matching_header_id;
+    END IF;
+
+    IF nonmatching_header_id != 0 AND block_number <= max_block_number - 15 THEN
+        RETURN nonmatching_header_id;
+    END IF;
+
+    IF nonmatching_header_id != 0 AND block_number > max_block_number - 15 THEN
+        DELETE FROM public.headers WHERE id = nonmatching_header_id;
+    END IF;
+
+    INSERT INTO public.headers (hash, block_number, raw, block_timestamp, eth_node_id)
+    VALUES (get_or_create_header.hash, get_or_create_header.block_number, get_or_create_header.raw,
+            get_or_create_header.block_timestamp, get_or_create_header.eth_node_id)
+    RETURNING id INTO inserted_header_id;
+
+    RETURN inserted_header_id;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -105,6 +105,7 @@ BEGIN
     INSERT INTO public.headers (hash, block_number, raw, block_timestamp, eth_node_id)
     VALUES (get_or_create_header.hash, get_or_create_header.block_number, get_or_create_header.raw,
             get_or_create_header.block_timestamp, get_or_create_header.eth_node_id)
+    ON CONFLICT DO NOTHING
     RETURNING id INTO inserted_header_id;
 
     RETURN inserted_header_id;

--- a/pkg/fakes/mock_header_repository.go
+++ b/pkg/fakes/mock_header_repository.go
@@ -35,6 +35,7 @@ type MockHeaderRepository struct {
 	GetHeadersInRangeEndingBlock           int64
 	GetHeadersInRangeError                 error
 	GetHeadersInRangeStartingBlock         int64
+	MissingBlockNumbersError               error
 	MostRecentHeaderBlockNumber            int64
 	MostRecentHeaderBlockNumberErr         error
 	createOrUpdateHeaderCallCount          int
@@ -96,7 +97,7 @@ func (mock *MockHeaderRepository) GetHeadersInRange(startingBlock, endingBlock i
 }
 
 func (mock *MockHeaderRepository) MissingBlockNumbers(startingBlockNumber, endingBlockNumber int64) ([]int64, error) {
-	return mock.missingBlockNumbers, nil
+	return mock.missingBlockNumbers, mock.MissingBlockNumbersError
 }
 
 func (mock *MockHeaderRepository) GetMostRecentHeaderBlockNumber() (int64, error) {

--- a/pkg/history/header_validator.go
+++ b/pkg/history/header_validator.go
@@ -38,14 +38,14 @@ func NewHeaderValidator(blockChain core.BlockChain, repository datastore.HeaderR
 }
 
 func (validator HeaderValidator) ValidateHeaders() (ValidationWindow, error) {
-	window, err := MakeValidationWindow(validator.blockChain, validator.windowSize)
-	if err != nil {
-		return ValidationWindow{}, fmt.Errorf("error creating validation window: %s", err.Error())
+	window, windowErr := MakeValidationWindow(validator.blockChain, validator.windowSize)
+	if windowErr != nil {
+		return ValidationWindow{}, fmt.Errorf("error creating validation window: %w", windowErr)
 	}
 	blockNumbers := MakeRange(window.LowerBound, window.UpperBound)
-	_, err = RetrieveAndUpdateHeaders(validator.blockChain, validator.headerRepository, blockNumbers)
-	if err != nil {
-		return ValidationWindow{}, fmt.Errorf("error getting/updating headers: %s", err.Error())
+	updateErr := RetrieveAndUpdateHeaders(validator.blockChain, validator.headerRepository, blockNumbers)
+	if updateErr != nil {
+		return ValidationWindow{}, fmt.Errorf("error getting/updating headers: %w", updateErr)
 	}
 	return window, nil
 }

--- a/pkg/history/populate_headers.go
+++ b/pkg/history/populate_headers.go
@@ -17,6 +17,8 @@
 package history
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/makerdao/vulcanizedb/pkg/core"
@@ -50,7 +52,7 @@ func RetrieveAndUpdateHeaders(blockChain core.BlockChain, headerRepository datas
 	headers, err := blockChain.GetHeadersByNumbers(blockNumbers)
 	for _, header := range headers {
 		_, err = headerRepository.CreateOrUpdateHeader(header)
-		if err != nil {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/history/populate_headers_test.go
+++ b/pkg/history/populate_headers_test.go
@@ -35,42 +35,31 @@ var _ = Describe("Populating headers", func() {
 		statusWriter = fakes.MockStatusWriter{}
 	})
 
-	It("returns number of headers added", func() {
-		blockChain := fakes.NewMockBlockChain()
-		blockChain.SetLastBlock(big.NewInt(2))
-		headerRepository.SetMissingBlockNumbers([]int64{2})
-
-		headersAdded, err := history.PopulateMissingHeaders(blockChain, headerRepository, 1)
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(headersAdded).To(Equal(1))
-	})
-
 	It("adds missing headers to the db", func() {
 		blockChain := fakes.NewMockBlockChain()
 		blockChain.SetLastBlock(big.NewInt(2))
 		headerRepository.SetMissingBlockNumbers([]int64{2})
 
-		_, err := history.PopulateMissingHeaders(blockChain, headerRepository, 1)
+		err := history.PopulateMissingHeaders(blockChain, headerRepository, 1)
 
 		Expect(err).NotTo(HaveOccurred())
 		headerRepository.AssertCreateOrUpdateHeaderCallCountAndPassedBlockNumbers(1, []int64{2})
 	})
 
-	It("returns early if the db is already synced up to the head of the chain", func() {
+	It("does not error if the db is already synced up to the head of the chain", func() {
 		blockChain := fakes.NewMockBlockChain()
 		blockChain.SetLastBlock(big.NewInt(2))
-		headersAdded, err := history.PopulateMissingHeaders(blockChain, headerRepository, 2)
+
+		err := history.PopulateMissingHeaders(blockChain, headerRepository, 2)
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(headersAdded).To(Equal(0))
 	})
 
 	It("Does not write a healthcheck file when the call to get the last block fails", func() {
 		blockChain := fakes.NewMockBlockChain()
 		blockChain.SetLastBlockError(fakes.FakeError)
 
-		_, err := history.PopulateMissingHeaders(blockChain, headerRepository, 1)
+		err := history.PopulateMissingHeaders(blockChain, headerRepository, 1)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(fakes.FakeError))


### PR DESCRIPTION
This PR takes a two pronged approach to avoiding constraint violations when concurrent processes are attempting to insert the same header:
1. Update the function that inserts headers to do nothing when there's a conflict. This will cause a `sql.ErrNoRows` when we try to scan the header ID for the inserted header, so we ignore that error upstream.
2. Cut off the `backfill` process for headers after it has filled headers from the configured starting block through to the head of the chain at the time the process was started. Only the header validation code is responsible for inserting new headers going forward.

One additional benefit of the second point is that we should stop making very heavyweight queries for all missing blocks between the configured starting block and the current head of the chain.

These updates required some additions to a few mocks. I'd like to clean those mocks up further but don't want to clutter the diff before folks have had a chance to review the core behavior changes.