### PR TITLE
(VDB-1532) Isolate beta env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ deploy:
 - provider: script
   script: bash ./.travis/deploy.sh staging
   on:
-    branch: staging
+    branch: beta
 - provider: script
   script: bash ./.travis/deploy.sh prod
   on:


### PR DESCRIPTION
The goal for this PR is to be able to merge breaking changes to staging and prod without having them deploy to the beta env.

The simplest fix seemed to be to only trigger a deploy to "staging" on updates to the `beta` branch.

This is obviously a bit confusing because the environment in the deploy is still known as "staging" since that's how it's referenced in the beta env.

Would welcome thoughts on if there's a better way - maybe we leave everything pointed at `staging` but just merge breaking changes to the `prod` branch (and don't merge breaking changes to `staging`)?