### PR TITLE
Add header repository to log extractor initializer

### DIFF
--- a/libraries/shared/logs/extractor.go
+++ b/libraries/shared/logs/extractor.go
@@ -62,6 +62,7 @@ func NewLogExtractor(db *postgres.DB, bc core.BlockChain) *LogExtractor {
 		CheckedHeadersRepository: repositories.NewCheckedHeadersRepository(db),
 		CheckedLogsRepository:    repositories.NewCheckedLogsRepository(db),
 		Fetcher:                  fetcher.NewLogFetcher(bc),
+		HeaderRepository:         repositories.NewHeaderRepository(db),
 		LogRepository:            repositories.NewEventLogRepository(db),
 		Syncer:                   transactions.NewTransactionsSyncer(db, bc),
 		RecheckHeaderCap:         constants.RecheckHeaderCap,


### PR DESCRIPTION
- so we can lookup headers to backfill