### PR TITLE
Chunk headers in backfill events process

### DIFF
--- a/libraries/shared/logs/extractor.go
+++ b/libraries/shared/logs/extractor.go
@@ -32,9 +32,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type BlockIdentifier string
+
 var (
-	ErrNoUncheckedHeaders = errors.New("no unchecked headers available for log fetching")
-	ErrNoWatchedAddresses = errors.New("no watched addresses configured in the log extractor")
+	StartInterval         BlockIdentifier = "start"
+	EndInterval           BlockIdentifier = "end"
+	ErrNoUncheckedHeaders                 = errors.New("no unchecked headers available for log fetching")
+	ErrNoWatchedAddresses                 = errors.New("no watched addresses configured in the log extractor")
+	HeaderChunkSize       int64           = 1000
 )
 
 type ILogExtractor interface {
@@ -152,19 +157,54 @@ func (extractor LogExtractor) BackFillLogs(endingBlock int64) error {
 		return fmt.Errorf("error extracting logs: %w", ErrNoWatchedAddresses)
 	}
 
-	headers, headersErr := extractor.HeaderRepository.GetHeadersInRange(*extractor.StartingBlock, endingBlock)
-	if headersErr != nil {
-		logrus.Errorf("error fetching missing headers: %s", headersErr)
-		return fmt.Errorf("error getting unchecked headers to check for logs: %w", headersErr)
+	ranges, chunkErr := ChunkRanges(*extractor.StartingBlock, endingBlock, HeaderChunkSize)
+	if chunkErr != nil {
+		return fmt.Errorf("error chunking headers to lookup in logs backfill: %w", chunkErr)
 	}
 
-	for _, header := range headers {
-		err := extractor.fetchAndPersistLogsForHeader(header)
-		if err != nil {
-			return fmt.Errorf("error fetching and persisting logs for header with id %d: %w", header.Id, err)
+	for _, r := range ranges {
+		headers, headersErr := extractor.HeaderRepository.GetHeadersInRange(r[StartInterval], r[EndInterval])
+		if headersErr != nil {
+			logrus.Errorf("error fetching missing headers: %s", headersErr)
+			return fmt.Errorf("error getting unchecked headers to check for logs: %w", headersErr)
+		}
+
+		for _, header := range headers {
+			err := extractor.fetchAndPersistLogsForHeader(header)
+			if err != nil {
+				return fmt.Errorf("error fetching and persisting logs for header with id %d: %w", header.Id, err)
+			}
 		}
 	}
+
 	return nil
+}
+
+func ChunkRanges(startingBlock, endingBlock, interval int64) ([]map[BlockIdentifier]int64, error) {
+	if endingBlock <= startingBlock {
+		return nil, errors.New("ending block for backfill not > starting block")
+	}
+
+	totalLength := endingBlock - startingBlock
+	numIntervals := totalLength / interval
+	if totalLength%interval != 0 {
+		numIntervals++
+	}
+
+	results := make([]map[BlockIdentifier]int64, numIntervals)
+	for i := int64(0); i < numIntervals; i++ {
+		nextStartBlock := startingBlock + i*interval
+		nextEndingBlock := nextStartBlock + interval - 1
+		if nextEndingBlock > endingBlock {
+			nextEndingBlock = endingBlock
+		}
+		nextInterval := map[BlockIdentifier]int64{
+			StartInterval: nextStartBlock,
+			EndInterval:   nextEndingBlock,
+		}
+		results[i] = nextInterval
+	}
+	return results, nil
 }
 
 func logError(description string, err error, header core.Header) {

--- a/libraries/shared/storage/backfill/storage_value_loader_test.go
+++ b/libraries/shared/storage/backfill/storage_value_loader_test.go
@@ -123,8 +123,8 @@ var _ = Describe("StorageValueLoader", func() {
 	It("fetches headers in the given block range", func() {
 		runnerErr := runner.Run()
 		Expect(runnerErr).NotTo(HaveOccurred())
-		Expect(headerRepo.GetHeadersInRangeStartingBlock).To(Equal(blockOne))
-		Expect(headerRepo.GetHeadersInRangeEndingBlock).To(Equal(blockTwo))
+		Expect(headerRepo.GetHeadersInRangeStartingBlocks).To(ConsistOf(blockOne))
+		Expect(headerRepo.GetHeadersInRangeEndingBlocks).To(ConsistOf(blockTwo))
 	})
 
 	It("returns an error if a header for the given block cannot be retrieved", func() {

--- a/pkg/fakes/mock_header_repository.go
+++ b/pkg/fakes/mock_header_repository.go
@@ -32,9 +32,9 @@ type MockHeaderRepository struct {
 	GetHeaderByIDError                     error
 	GetHeaderByIDHeaderToReturn            core.Header
 	GetHeaderPassedBlockNumber             int64
-	GetHeadersInRangeEndingBlock           int64
+	GetHeadersInRangeEndingBlocks          []int64
 	GetHeadersInRangeError                 error
-	GetHeadersInRangeStartingBlock         int64
+	GetHeadersInRangeStartingBlocks        []int64
 	MostRecentHeaderBlockNumber            int64
 	MostRecentHeaderBlockNumberErr         error
 	createOrUpdateHeaderCallCount          int
@@ -90,8 +90,8 @@ func (mock *MockHeaderRepository) GetHeaderByID(id int64) (core.Header, error) {
 }
 
 func (mock *MockHeaderRepository) GetHeadersInRange(startingBlock, endingBlock int64) ([]core.Header, error) {
-	mock.GetHeadersInRangeStartingBlock = startingBlock
-	mock.GetHeadersInRangeEndingBlock = endingBlock
+	mock.GetHeadersInRangeStartingBlocks = append(mock.GetHeadersInRangeStartingBlocks, startingBlock)
+	mock.GetHeadersInRangeEndingBlocks = append(mock.GetHeadersInRangeEndingBlocks, endingBlock)
 	return mock.AllHeaders, mock.GetHeadersInRangeError
 }
 


### PR DESCRIPTION
- Don't load all headers in range into memory; chunk into manageable
  quantity (currently 1000 headers per lookup)