### PR TITLE
VDB-1629 - Have CheckedHeadersRepository use the plugin schema specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ test: | $(GINKGO) $(LINT)
 
 .PHONY: integrationtest
 integrationtest: | $(GINKGO) $(LINT)
+	test -n "$(CLIENT_IPCPATH)" # $$(CLIENT_IPCPATH)
 	go vet ./...
 	go fmt ./...
 	dropdb --if-exists $(TEST_DB)

--- a/cmd/backfillEvents.go
+++ b/cmd/backfillEvents.go
@@ -53,7 +53,7 @@ func backFillEvents() error {
 
 	repo, repoErr := repositories.NewCheckedHeadersRepository(&db, genConfig.Schema)
 	if repoErr != nil {
-		return fmt.Errorf("error creating checked headers repository %w", repoErr)
+		return fmt.Errorf("error creating checked headers repository %w for schema %s", repoErr, genConfig.Schema)
 	}
 	extractor := logs.NewLogExtractor(&db, blockChain, repo)
 

--- a/cmd/backfillEvents.go
+++ b/cmd/backfillEvents.go
@@ -51,7 +51,7 @@ func backFillEvents() error {
 	blockChain := getBlockChain()
 	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
 
-	extractor := logs.NewLogExtractor(&db, blockChain, repositories.NewCheckedHeadersRepository(&db))
+	extractor := logs.NewLogExtractor(&db, blockChain, repositories.NewCheckedHeadersRepository(&db, genConfig.Schema))
 
 	for _, initializer := range ethEventInitializers {
 		transformer := initializer(&db)

--- a/cmd/backfillEvents.go
+++ b/cmd/backfillEvents.go
@@ -51,7 +51,11 @@ func backFillEvents() error {
 	blockChain := getBlockChain()
 	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
 
-	extractor := logs.NewLogExtractor(&db, blockChain, repositories.NewCheckedHeadersRepository(&db, genConfig.Schema))
+	repo, repoErr := repositories.NewCheckedHeadersRepository(&db, genConfig.Schema)
+	if repoErr != nil {
+		return fmt.Errorf("error creating checked headers repository %w", repoErr)
+	}
+	extractor := logs.NewLogExtractor(&db, blockChain, repo)
 
 	for _, initializer := range ethEventInitializers {
 		transformer := initializer(&db)

--- a/cmd/backfillEvents.go
+++ b/cmd/backfillEvents.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/makerdao/vulcanizedb/libraries/shared/logs"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,7 +51,7 @@ func backFillEvents() error {
 	blockChain := getBlockChain()
 	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
 
-	extractor := logs.NewLogExtractor(&db, blockChain)
+	extractor := logs.NewLogExtractor(&db, blockChain, repositories.NewCheckedHeadersRepository(&db))
 
 	for _, initializer := range ethEventInitializers {
 		transformer := initializer(&db)

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -100,7 +99,7 @@ func executeTransformers() {
 	if len(ethEventInitializers) > 0 {
 		repo, repoErr := repositories.NewCheckedHeadersRepository(&db, genConfig.Schema)
 		if repoErr != nil {
-			LogWithCommand.Fatalf(fmt.Errorf("failed to create checked headers repository: %w", repoErr).Error())
+			LogWithCommand.Fatalf("failed to create checked headers repository %s for schema %s", repoErr.Error(), genConfig.Schema)
 		}
 		extractor := logs.NewLogExtractor(&db, blockChain, repo)
 		delegator := logs.NewLogDelegator(&db)

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -97,7 +97,7 @@ func executeTransformers() {
 	// Use WaitGroup to wait on both goroutines
 	var wg sync.WaitGroup
 	if len(ethEventInitializers) > 0 {
-		extractor := logs.NewLogExtractor(&db, blockChain, repositories.NewCheckedHeadersRepository(&db))
+		extractor := logs.NewLogExtractor(&db, blockChain, repositories.NewCheckedHeadersRepository(&db, genConfig.Schema))
 		delegator := logs.NewLogDelegator(&db)
 		eventHealthCheckMessage := []byte("event watcher starting\n")
 		statusWriter := fs.NewStatusWriter(healthCheckFile, eventHealthCheckMessage)

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -97,7 +98,11 @@ func executeTransformers() {
 	// Use WaitGroup to wait on both goroutines
 	var wg sync.WaitGroup
 	if len(ethEventInitializers) > 0 {
-		extractor := logs.NewLogExtractor(&db, blockChain, repositories.NewCheckedHeadersRepository(&db, genConfig.Schema))
+		repo, repoErr := repositories.NewCheckedHeadersRepository(&db, genConfig.Schema)
+		if repoErr != nil {
+			LogWithCommand.Fatalf(fmt.Errorf("failed to create checked headers repository: %w", repoErr).Error())
+		}
+		extractor := logs.NewLogExtractor(&db, blockChain, repo)
 		delegator := logs.NewLogDelegator(&db)
 		eventHealthCheckMessage := []byte("event watcher starting\n")
 		statusWriter := fs.NewStatusWriter(healthCheckFile, eventHealthCheckMessage)

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -26,6 +26,7 @@ import (
 	"github.com/makerdao/vulcanizedb/libraries/shared/logs"
 	"github.com/makerdao/vulcanizedb/libraries/shared/transformer"
 	"github.com/makerdao/vulcanizedb/libraries/shared/watcher"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fs"
 	"github.com/makerdao/vulcanizedb/utils"
 	"github.com/sirupsen/logrus"
@@ -96,7 +97,7 @@ func executeTransformers() {
 	// Use WaitGroup to wait on both goroutines
 	var wg sync.WaitGroup
 	if len(ethEventInitializers) > 0 {
-		extractor := logs.NewLogExtractor(&db, blockChain)
+		extractor := logs.NewLogExtractor(&db, blockChain, repositories.NewCheckedHeadersRepository(&db))
 		delegator := logs.NewLogDelegator(&db)
 		eventHealthCheckMessage := []byte("event watcher starting\n")
 		statusWriter := fs.NewStatusWriter(healthCheckFile, eventHealthCheckMessage)

--- a/cmd/resetHeaderCheckCount.go
+++ b/cmd/resetHeaderCheckCount.go
@@ -64,6 +64,11 @@ func init() {
 func resetHeaderCount(blockNumber int64) error {
 	blockChain := getBlockChain()
 	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
-	repo := repositories.NewCheckedHeadersRepository(&db, genConfig.Schema)
+	repo, repoErr := repositories.NewCheckedHeadersRepository(&db, genConfig.Schema)
+
+	if repoErr != nil {
+		return fmt.Errorf("error creating checked headers repository %w", repoErr)
+	}
+
 	return repo.MarkSingleHeaderUnchecked(blockNumber)
 }

--- a/cmd/resetHeaderCheckCount.go
+++ b/cmd/resetHeaderCheckCount.go
@@ -64,6 +64,6 @@ func init() {
 func resetHeaderCount(blockNumber int64) error {
 	blockChain := getBlockChain()
 	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
-	repo := repositories.NewCheckedHeadersRepository(&db)
+	repo := repositories.NewCheckedHeadersRepository(&db, genConfig.Schema)
 	return repo.MarkSingleHeaderUnchecked(blockNumber)
 }

--- a/db/migrations/00003_create_headers_table.sql
+++ b/db/migrations/00003_create_headers_table.sql
@@ -6,7 +6,6 @@ CREATE TABLE public.headers
     block_number    BIGINT      NOT NULL,
     raw             JSONB,
     block_timestamp NUMERIC,
-    check_count     INTEGER     NOT NULL DEFAULT 0,
     eth_node_id     INTEGER     NOT NULL REFERENCES eth_nodes (id) ON DELETE CASCADE,
     created         TIMESTAMP   NOT NULL DEFAULT NOW(),
     updated         TIMESTAMP   NOT NULL DEFAULT NOW(),
@@ -33,8 +32,6 @@ CREATE INDEX headers_block_number
     ON public.headers (block_number);
 CREATE INDEX headers_block_timestamp_index
     ON public.headers (block_timestamp);
-CREATE INDEX headers_check_count
-    ON public.headers (check_count);
 CREATE INDEX headers_eth_node
     ON public.headers (eth_node_id);
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -388,7 +388,6 @@ CREATE TABLE public.headers (
     block_number bigint NOT NULL,
     raw jsonb,
     block_timestamp numeric,
-    check_count integer DEFAULT 0 NOT NULL,
     eth_node_id integer NOT NULL,
     created timestamp without time zone DEFAULT now() NOT NULL,
     updated timestamp without time zone DEFAULT now() NOT NULL
@@ -813,13 +812,6 @@ CREATE INDEX headers_block_number ON public.headers USING btree (block_number);
 --
 
 CREATE INDEX headers_block_timestamp_index ON public.headers USING btree (block_timestamp);
-
-
---
--- Name: headers_check_count; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX headers_check_count ON public.headers USING btree (check_count);
 
 
 --

--- a/integration_test/contract_watcher_transformer_test.go
+++ b/integration_test/contract_watcher_transformer_test.go
@@ -29,14 +29,13 @@ import (
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
-	"github.com/makerdao/vulcanizedb/test_config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("contractWatcher transformer", func() {
 	var (
-		db               = test_config.NewTestDB(test_config.NewTestNode())
+		db               *postgres.DB
 		err              error
 		blockChain       core.BlockChain
 		headerRepository datastore.HeaderRepository

--- a/integration_test/contract_watcher_transformer_test.go
+++ b/integration_test/contract_watcher_transformer_test.go
@@ -27,15 +27,15 @@ import (
 	"github.com/makerdao/vulcanizedb/pkg/contract_watcher/transformer"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
-	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
+	"github.com/makerdao/vulcanizedb/test_config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("contractWatcher transformer", func() {
 	var (
-		db               *postgres.DB
+		db               = test_config.NewTestDB(test_config.NewTestNode())
 		err              error
 		blockChain       core.BlockChain
 		headerRepository datastore.HeaderRepository
@@ -46,12 +46,6 @@ var _ = Describe("contractWatcher transformer", func() {
 
 	BeforeEach(func() {
 		blockChain = SetupBC()
-		db, err := postgres.NewDB(config.Database{
-			Hostname: "localhost",
-			Name:     "vulcanize_testing",
-			Port:     5432,
-		}, blockChain.Node())
-		Expect(err).NotTo(HaveOccurred())
 		headerRepository = repositories.NewHeaderRepository(db)
 	})
 

--- a/integration_test/contract_watcher_transformer_test.go
+++ b/integration_test/contract_watcher_transformer_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package integration
+package integration_test
 
 import (
 	"fmt"
@@ -27,15 +27,15 @@ import (
 	"github.com/makerdao/vulcanizedb/pkg/contract_watcher/transformer"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
-	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
+	"github.com/makerdao/vulcanizedb/test_config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("contractWatcher transformer", func() {
 	var (
-		db               *postgres.DB
+		db               = test_config.NewTestDB(test_config.NewTestNode())
 		err              error
 		blockChain       core.BlockChain
 		headerRepository datastore.HeaderRepository
@@ -45,7 +45,7 @@ var _ = Describe("contractWatcher transformer", func() {
 	)
 
 	BeforeEach(func() {
-		db, blockChain = test_helpers.SetupDBandBC()
+		db, blockChain = SetupDBandBC()
 		headerRepository = repositories.NewHeaderRepository(db)
 	})
 

--- a/integration_test/contract_watcher_transformer_test.go
+++ b/integration_test/contract_watcher_transformer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/makerdao/vulcanizedb/pkg/contract_watcher/transformer"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/test_config"
 	. "github.com/onsi/ginkgo"
@@ -45,7 +46,13 @@ var _ = Describe("contractWatcher transformer", func() {
 	)
 
 	BeforeEach(func() {
-		db, blockChain = SetupDBandBC()
+		blockChain = SetupBC()
+		db, err := postgres.NewDB(config.Database{
+			Hostname: "localhost",
+			Name:     "vulcanize_testing",
+			Port:     5432,
+		}, blockChain.Node())
+		Expect(err).NotTo(HaveOccurred())
 		headerRepository = repositories.NewHeaderRepository(db)
 	})
 

--- a/integration_test/geth_blockchain_test.go
+++ b/integration_test/geth_blockchain_test.go
@@ -25,18 +25,17 @@ import (
 	"github.com/makerdao/vulcanizedb/pkg/eth/client"
 	"github.com/makerdao/vulcanizedb/pkg/eth/converters"
 	"github.com/makerdao/vulcanizedb/pkg/eth/node"
-	"github.com/makerdao/vulcanizedb/test_config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Reading from the Geth blockchain", func() {
-	var blockChain *eth.BlockChain
+	var blockChain core.BlockChain
 
 	BeforeEach(func() {
-		rawRpcClient, err := rpc.Dial(test_config.TestClient.IPCPath)
+		rawRpcClient, err := rpc.Dial(TestClient.IPCPath)
 		Expect(err).NotTo(HaveOccurred())
-		rpcClient := client.NewRpcClient(rawRpcClient, test_config.TestClient.IPCPath)
+		rpcClient := client.NewRpcClient(rawRpcClient, TestClient.IPCPath)
 		ethClient := ethclient.NewClient(rawRpcClient)
 		blockChainClient := client.NewEthClient(ethClient)
 		node := node.MakeNode(rpcClient)

--- a/integration_test/geth_blockchain_test.go
+++ b/integration_test/geth_blockchain_test.go
@@ -18,13 +18,7 @@ package integration_test
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/makerdao/vulcanizedb/pkg/core"
-	"github.com/makerdao/vulcanizedb/pkg/eth"
-	"github.com/makerdao/vulcanizedb/pkg/eth/client"
-	"github.com/makerdao/vulcanizedb/pkg/eth/converters"
-	"github.com/makerdao/vulcanizedb/pkg/eth/node"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -33,14 +27,7 @@ var _ = Describe("Reading from the Geth blockchain", func() {
 	var blockChain core.BlockChain
 
 	BeforeEach(func() {
-		rawRpcClient, err := rpc.Dial(TestClient.IPCPath)
-		Expect(err).NotTo(HaveOccurred())
-		rpcClient := client.NewRpcClient(rawRpcClient, TestClient.IPCPath)
-		ethClient := ethclient.NewClient(rawRpcClient)
-		blockChainClient := client.NewEthClient(ethClient)
-		node := node.MakeNode(rpcClient)
-		transactionConverter := converters.NewTransactionConverter(ethClient)
-		blockChain = eth.NewBlockChain(blockChainClient, rpcClient, node, transactionConverter)
+		blockChain = SetupBC()
 	})
 
 	It("retrieves the node info", func(done Done) {

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -1,0 +1,59 @@
+package integration_test
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/makerdao/vulcanizedb/pkg/config"
+	"github.com/makerdao/vulcanizedb/pkg/core"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
+	"github.com/makerdao/vulcanizedb/pkg/eth"
+	"github.com/makerdao/vulcanizedb/pkg/eth/client"
+	"github.com/makerdao/vulcanizedb/pkg/eth/converters"
+	"github.com/makerdao/vulcanizedb/pkg/eth/node"
+	"github.com/makerdao/vulcanizedb/test_config"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var TestClient config.Client
+
+func init() {
+	ipc := test_config.TestConfig.GetString("client.ipcPath")
+
+	// If we don't have an ipc path in the config file, check the env variable
+	if ipc == "" {
+		test_config.TestConfig.BindEnv("url", "CLIENT_IPCPATH")
+		ipc = test_config.TestConfig.GetString("url")
+	}
+	if ipc == "" {
+		logrus.Fatal(errors.New("testing.toml IPC path or $CLIENT_IPCPATH env variable need to be set"))
+	}
+
+	TestClient = config.Client{
+		IPCPath: ipc,
+	}
+}
+
+func SetupDBandBC() (*postgres.DB, core.BlockChain) {
+	con := TestClient
+	testIPC := con.IPCPath
+	rawRPCClient, err := rpc.Dial(testIPC)
+	Expect(err).NotTo(HaveOccurred())
+	rpcClient := client.NewRpcClient(rawRPCClient, testIPC)
+	ethClient := ethclient.NewClient(rawRPCClient)
+	blockChainClient := client.NewEthClient(ethClient)
+	madeNode := node.MakeNode(rpcClient)
+	transactionConverter := converters.NewTransactionConverter(ethClient)
+	blockChain := eth.NewBlockChain(blockChainClient, rpcClient, madeNode, transactionConverter)
+
+	db, err := postgres.NewDB(config.Database{
+		Hostname: "localhost",
+		Name:     "vulcanize_testing",
+		Port:     5432,
+	}, blockChain.Node())
+	Expect(err).NotTo(HaveOccurred())
+
+	return db, blockChain
+}

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/makerdao/vulcanizedb/pkg/config"
 	"github.com/makerdao/vulcanizedb/pkg/core"
-	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/eth"
 	"github.com/makerdao/vulcanizedb/pkg/eth/client"
 	"github.com/makerdao/vulcanizedb/pkg/eth/converters"
@@ -36,7 +35,7 @@ func init() {
 	}
 }
 
-func SetupDBandBC() (*postgres.DB, core.BlockChain) {
+func SetupBC() core.BlockChain {
 	con := TestClient
 	testIPC := con.IPCPath
 	rawRPCClient, err := rpc.Dial(testIPC)
@@ -48,12 +47,5 @@ func SetupDBandBC() (*postgres.DB, core.BlockChain) {
 	transactionConverter := converters.NewTransactionConverter(ethClient)
 	blockChain := eth.NewBlockChain(blockChainClient, rpcClient, madeNode, transactionConverter)
 
-	db, err := postgres.NewDB(config.Database{
-		Hostname: "localhost",
-		Name:     "vulcanize_testing",
-		Port:     5432,
-	}, blockChain.Node())
-	Expect(err).NotTo(HaveOccurred())
-
-	return db, blockChain
+	return blockChain
 }

--- a/libraries/shared/logs/extractor.go
+++ b/libraries/shared/logs/extractor.go
@@ -62,9 +62,9 @@ type LogExtractor struct {
 	RecheckHeaderCap         int64
 }
 
-func NewLogExtractor(db *postgres.DB, bc core.BlockChain) *LogExtractor {
+func NewLogExtractor(db *postgres.DB, bc core.BlockChain, chr datastore.CheckedHeadersRepository) *LogExtractor {
 	return &LogExtractor{
-		CheckedHeadersRepository: repositories.NewCheckedHeadersRepository(db),
+		CheckedHeadersRepository: chr,
 		CheckedLogsRepository:    repositories.NewCheckedLogsRepository(db),
 		Fetcher:                  fetcher.NewLogFetcher(bc),
 		HeaderRepository:         repositories.NewHeaderRepository(db),

--- a/libraries/shared/test_data/test_helpers.go
+++ b/libraries/shared/test_data/test_helpers.go
@@ -90,12 +90,20 @@ func getRandomAddress() string {
 	return stringHash[:42]
 }
 
-/// DescribeAValidCheckedHeadersModelWithSchema is provided so that
+/// ExpectCheckedHeadersInThisSchema is provided so that
 /// plugins can easily validate that they have the necessary checked_headers
 /// table in their schema for the execute process.
 ///
 /// Use like so in your tests:
-/// var _ = test_data.DescribeAValidCheckedHeadersModelWithSchema("schemaName")
+/// var _ = Describe("Your Schema", func() {
+///		BeforeEach(func() {
+///			test_config.CleanTestDB(db)
+///		})
+///
+///		It("has a proper checked headers setup in the schema", func() {
+///			test_data.ExpectCheckedHeadersInThisSchema(db, "yourschemaname")
+///		})
+/// })
 func ExpectCheckedHeadersInThisSchema(db *postgres.DB, schema string) {
 	Expect(db).NotTo(BeNil())
 	// insert header

--- a/pkg/contract_watcher/helpers/test_helpers/database.go
+++ b/pkg/contract_watcher/helpers/test_helpers/database.go
@@ -17,19 +17,12 @@
 package test_helpers
 
 import (
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/makerdao/vulcanizedb/pkg/config"
 	"github.com/makerdao/vulcanizedb/pkg/contract_watcher/constants"
 	"github.com/makerdao/vulcanizedb/pkg/contract_watcher/contract"
 	"github.com/makerdao/vulcanizedb/pkg/contract_watcher/helpers/test_helpers/mocks"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
-	"github.com/makerdao/vulcanizedb/pkg/eth"
-	"github.com/makerdao/vulcanizedb/pkg/eth/client"
-	"github.com/makerdao/vulcanizedb/pkg/eth/converters"
-	"github.com/makerdao/vulcanizedb/pkg/eth/node"
-	"github.com/makerdao/vulcanizedb/test_config"
 	. "github.com/onsi/gomega"
 )
 
@@ -53,28 +46,6 @@ type NewOwnerLog struct {
 	Label    string `db:"label_"`
 	Owner    string `db:"owner_"`
 	RawLog   []byte `db:"raw_log"`
-}
-
-func SetupDBandBC() (*postgres.DB, core.BlockChain) {
-	con := test_config.TestClient
-	testIPC := con.IPCPath
-	rawRPCClient, err := rpc.Dial(testIPC)
-	Expect(err).NotTo(HaveOccurred())
-	rpcClient := client.NewRpcClient(rawRPCClient, testIPC)
-	ethClient := ethclient.NewClient(rawRPCClient)
-	blockChainClient := client.NewEthClient(ethClient)
-	madeNode := node.MakeNode(rpcClient)
-	transactionConverter := converters.NewTransactionConverter(ethClient)
-	blockChain := eth.NewBlockChain(blockChainClient, rpcClient, madeNode, transactionConverter)
-
-	db, err := postgres.NewDB(config.Database{
-		Hostname: "localhost",
-		Name:     "vulcanize_testing",
-		Port:     5432,
-	}, blockChain.Node())
-	Expect(err).NotTo(HaveOccurred())
-
-	return db, blockChain
 }
 
 func SetupTusdRepo(wantedEvents []string) (*postgres.DB, *contract.Contract) {
@@ -167,14 +138,6 @@ func TearDown(db *postgres.DB) {
 	_, err = tx.Exec(`DELETE FROM public.receipts`)
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = tx.Exec(`DROP TABLE public.checked_headers`)
-	Expect(err).NotTo(HaveOccurred())
-
-	_, err = tx.Exec(`CREATE TABLE public.checked_headers (
-    	id SERIAL PRIMARY KEY,
-    	header_id INTEGER UNIQUE NOT NULL REFERENCES headers (id) ON DELETE CASCADE);`)
-	Expect(err).NotTo(HaveOccurred())
-
 	_, err = tx.Exec(`DROP SCHEMA IF EXISTS cw_0x8dd5fbce2f6a956c3022ba3663759011dd51e73e CASCADE`)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -184,6 +147,25 @@ func TearDown(db *postgres.DB) {
 	err = tx.Commit()
 	Expect(err).NotTo(HaveOccurred())
 
+	err = ResetCheckedHeadersTableSchema(db)
+	Expect(err).NotTo(HaveOccurred())
+
 	_, err = db.Exec(`VACUUM public.checked_headers`)
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func ResetCheckedHeadersTableSchema(db *postgres.DB) error {
+	_, dropTableErr := db.Exec(`DROP TABLE public.checked_headers`)
+	if dropTableErr != nil {
+		return dropTableErr
+	}
+
+	_, createTableErr := db.Exec(`CREATE TABLE public.checked_headers (
+		id SERIAL PRIMARY KEY,
+    	header_id INTEGER UNIQUE NOT NULL REFERENCES headers (id) ON DELETE CASCADE);`)
+	if createTableErr != nil {
+		return createTableErr
+	}
+
+	return nil
 }

--- a/pkg/contract_watcher/repository/header_repository_test.go
+++ b/pkg/contract_watcher/repository/header_repository_test.go
@@ -24,15 +24,15 @@ import (
 	"github.com/makerdao/vulcanizedb/pkg/contract_watcher/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
-	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
+	"github.com/makerdao/vulcanizedb/test_config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Repository", func() {
 	var (
-		db                 *postgres.DB
+		db                 = test_config.NewTestDB(test_config.NewTestNode())
 		contractHeaderRepo repository.HeaderRepository // contract_watcher header repository
 		coreHeaderRepo     datastore.HeaderRepository  // pkg/datastore header repository
 		eventIDs           = []string{
@@ -43,13 +43,14 @@ var _ = Describe("Repository", func() {
 	)
 
 	BeforeEach(func() {
-		db, _ = test_helpers.SetupDBandBC()
+		test_config.CleanTestDB(db)
 		contractHeaderRepo = repository.NewHeaderRepository(db)
 		coreHeaderRepo = repositories.NewHeaderRepository(db)
 	})
 
 	AfterEach(func() {
-		test_helpers.TearDown(db)
+		err := test_helpers.ResetCheckedHeadersTableSchema(db)
+		Expect(err).NotTo(HaveOccurred(), "Failed to reset checked headers table in teardown")
 	})
 
 	Describe("AddCheckColumn", func() {

--- a/pkg/datastore/postgres/repositories/checked_headers_repository.go
+++ b/pkg/datastore/postgres/repositories/checked_headers_repository.go
@@ -29,7 +29,7 @@ type CheckedHeadersRepository struct {
 	db *postgres.DB
 }
 
-func NewCheckedHeadersRepository(db *postgres.DB) CheckedHeadersRepository {
+func NewCheckedHeadersRepository(db *postgres.DB, schemaName string) CheckedHeadersRepository {
 	return CheckedHeadersRepository{db: db}
 }
 

--- a/pkg/datastore/postgres/repositories/checked_headers_repository.go
+++ b/pkg/datastore/postgres/repositories/checked_headers_repository.go
@@ -17,31 +17,47 @@
 package repositories
 
 import (
+	"fmt"
+
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
 
 const (
-	insertCheckedHeaderQuery = `UPDATE public.headers SET check_count = (SELECT check_count WHERE id = $1) + 1 WHERE id = $1`
+	insertCheckedHeaderQuery = `
+INSERT INTO %s.checked_headers (check_count, header_id)
+VALUES (1, $1)
+ON CONFLICT (header_id) DO
+	UPDATE SET check_count =
+		(SELECT checked_headers.check_count WHERE checked_headers.header_id = $1) + 1
+	WHERE checked_headers.header_id = $1`
 )
 
 type CheckedHeadersRepository struct {
-	db *postgres.DB
+	db         *postgres.DB
+	schemaName string
 }
 
 func NewCheckedHeadersRepository(db *postgres.DB, schemaName string) CheckedHeadersRepository {
-	return CheckedHeadersRepository{db: db}
+	return CheckedHeadersRepository{db: db, schemaName: schemaName}
 }
 
 // Increment check_count for header
 func (repo CheckedHeadersRepository) MarkHeaderChecked(headerID int64) error {
-	_, err := repo.db.Exec(insertCheckedHeaderQuery, headerID)
+	queryString := fmt.Sprintf(insertCheckedHeaderQuery, repo.schemaName)
+	_, err := repo.db.Exec(queryString, headerID)
 	return err
 }
 
 // Zero out check count for header with the given block number
 func (repo CheckedHeadersRepository) MarkSingleHeaderUnchecked(blockNumber int64) error {
-	_, err := repo.db.Exec(`UPDATE public.headers SET check_count = 0 WHERE block_number = $1`, blockNumber)
+	queryString := fmt.Sprintf(`UPDATE %s.checked_headers ch
+								SET check_count = 0
+								FROM public.headers h
+								WHERE ch.header_id = h.id
+								AND h.block_number = $1`, repo.schemaName)
+
+	_, err := repo.db.Exec(queryString, blockNumber)
 	return err
 }
 
@@ -54,25 +70,25 @@ func (repo CheckedHeadersRepository) UncheckedHeaders(startingBlockNumber, endin
 		recheckOffsetMultiplier = 15
 	)
 
+	query = fmt.Sprintf(`SELECT h.id, h.block_number, h.hash
+						FROM public.headers h
+						LEFT JOIN %s.checked_headers ch
+						ON ch.header_id = h.id`, repo.schemaName)
+
 	if endingBlockNumber == -1 {
-		query = `SELECT id, block_number, hash
-			FROM public.headers
-			WHERE (check_count < 1
-			           AND block_number >= $1)
-			   OR (check_count < $2
-			           AND block_number <= ((SELECT MAX(block_number) FROM public.headers) - ($3 * check_count * (check_count + 1) / 2)))`
-		err = repo.db.Select(&result, query, startingBlockNumber, checkCount, recheckOffsetMultiplier)
+		noEndingBlockQuery := fmt.Sprintf(`%s
+				 WHERE ((ch.check_count IS NULL OR ch.check_count < 1) AND h.block_number >= $1)
+				 OR ((ch.check_count IS NULL OR ch.check_count < $2)
+			           AND h.block_number <= ((SELECT MAX(block_number) FROM public.headers) - ($3 * ch.check_count * (ch.check_count + 1) / 2)))`, query)
+		err = repo.db.Select(&result, noEndingBlockQuery, startingBlockNumber, checkCount, recheckOffsetMultiplier)
 	} else {
-		query = `SELECT id, block_number, hash
-			FROM public.headers
-			WHERE (check_count < 1
-			           AND block_number >= $1
-			           AND block_number <= $2)
-			   OR (check_count < $3
-			           AND block_number >= $1
-			           AND block_number <= $2
-			           AND block_number <= ((SELECT MAX(block_number) FROM public.headers) - ($4 * (check_count * (check_count + 1) / 2))))`
-		err = repo.db.Select(&result, query, startingBlockNumber, endingBlockNumber, checkCount, recheckOffsetMultiplier)
+		endingBlockQuery := fmt.Sprintf(`%s
+        WHERE ((ch.check_count IS NULL OR ch.check_count < 1) AND h.block_number >= $1 AND h.block_number <= $2)
+		OR ((ch.check_count IS NULL OR ch.check_count < $3)
+			AND h.block_number >= $1
+			AND h.block_number <= $2
+			AND h.block_number <= ((SELECT MAX(block_number) FROM public.headers) - ($4 * (ch.check_count * (ch.check_count + 1) / 2))))`, query)
+		err = repo.db.Select(&result, endingBlockQuery, startingBlockNumber, endingBlockNumber, checkCount, recheckOffsetMultiplier)
 	}
 
 	return result, err

--- a/pkg/datastore/postgres/repositories/checked_headers_repository_test.go
+++ b/pkg/datastore/postgres/repositories/checked_headers_repository_test.go
@@ -171,6 +171,28 @@ var _ = Describe("Checked Headers repository", func() {
 					Expect(headerBlockNumbers).NotTo(ContainElement(lastBlock))
 				})
 
+				It("includes headers that have had their check-count reset", func() {
+					Expect(repo.MarkHeaderChecked(secondHeaderID)).To(Succeed())
+					Expect(repo.MarkSingleHeaderUnchecked(secondBlock)).To(Succeed())
+
+					headers, err := repo.UncheckedHeaders(firstBlock, thirdBlock, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+
+					headerBlockNumbers := getBlockNumbers(headers)
+					Expect(headerBlockNumbers).To(ConsistOf(firstBlock, secondBlock, thirdBlock))
+					Expect(headerBlockNumbers).NotTo(ContainElement(lastBlock))
+				})
+
+				It("excludes headers that are before the first block number", func() {
+					headers, err := repo.UncheckedHeaders(firstBlock+1, thirdBlock, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+
+					headerBlockNumbers := getBlockNumbers(headers)
+					Expect(headerBlockNumbers).To(ConsistOf(secondBlock, thirdBlock))
+					Expect(headerBlockNumbers).NotTo(ContainElement(firstBlock))
+					Expect(headerBlockNumbers).NotTo(ContainElement(lastBlock))
+				})
+
 				It("excludes headers that have been checked more than the check count", func() {
 					Expect(repo.MarkHeaderChecked(secondHeaderID)).To(Succeed())
 
@@ -183,6 +205,16 @@ var _ = Describe("Checked Headers repository", func() {
 				})
 
 				Describe("when header has already been checked", func() {
+					It("excludes headers that are before the first block number", func() {
+						Expect(repo.MarkHeaderChecked(thirdHeaderID)).To(Succeed())
+
+						headers, err := repo.UncheckedHeaders(thirdBlock+1, lastBlock, recheckCheckCount)
+						Expect(err).NotTo(HaveOccurred())
+
+						headerBlockNumbers := getBlockNumbers(headers)
+						Expect(headerBlockNumbers).NotTo(ContainElement(thirdBlock))
+					})
+
 					It("includes header with block number >= 15 back from latest with check count of 1", func() {
 						Expect(repo.MarkHeaderChecked(thirdHeaderID)).To(Succeed())
 
@@ -266,6 +298,18 @@ var _ = Describe("Checked Headers repository", func() {
 					Expect(headerBlockNumbers).To(ConsistOf(firstBlock, secondBlock, thirdBlock, lastBlock))
 				})
 
+				It("includes headers that have had their check-count reset", func() {
+					Expect(repo.MarkHeaderChecked(secondHeaderID)).To(Succeed())
+					Expect(repo.MarkSingleHeaderUnchecked(secondBlock)).To(Succeed())
+
+					headers, err := repo.UncheckedHeaders(firstBlock, thirdBlock, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+
+					headerBlockNumbers := getBlockNumbers(headers)
+					Expect(headerBlockNumbers).To(ConsistOf(firstBlock, secondBlock, thirdBlock))
+					Expect(headerBlockNumbers).NotTo(ContainElement(lastBlock))
+				})
+
 				It("excludes headers that have been checked more than the check count", func() {
 					Expect(repo.MarkHeaderChecked(headerIDs[1])).To(Succeed())
 
@@ -275,6 +319,16 @@ var _ = Describe("Checked Headers repository", func() {
 					headerBlockNumbers := getBlockNumbers(headers)
 					Expect(headerBlockNumbers).To(ConsistOf(firstBlock, thirdBlock, lastBlock))
 					Expect(headerBlockNumbers).NotTo(ContainElement(secondBlock))
+				})
+
+				It("excludes headers that are before the first block number", func() {
+					repo.MarkSingleHeaderUnchecked(secondBlock)
+					headers, err := repo.UncheckedHeaders(firstBlock+1, -1, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+
+					headerBlockNumbers := getBlockNumbers(headers)
+					Expect(headerBlockNumbers).To(ConsistOf(secondBlock, thirdBlock, lastBlock))
+					Expect(headerBlockNumbers).NotTo(ContainElement(firstBlock))
 				})
 
 				Describe("when header has already been checked", func() {

--- a/pkg/datastore/postgres/repositories/checked_headers_repository_test.go
+++ b/pkg/datastore/postgres/repositories/checked_headers_repository_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Checked Headers repository", func() {
 			})
 
 			Describe("when header has already been checked", func() {
-				It("includes header with block number > 15 back from latest with check count of 1", func() {
+				It("includes header with block number >= 15 back from latest with check count of 1", func() {
 					err := repo.MarkHeaderChecked(thirdHeaderID)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -241,8 +241,10 @@ var _ = Describe("Checked Headers repository", func() {
 				It("includes header with block number > 45 back from latest with check count of 2", func() {
 					err := repo.MarkHeaderChecked(secondHeaderID)
 					Expect(err).NotTo(HaveOccurred())
+					secondMarkErr := repo.MarkHeaderChecked(secondHeaderID)
+					Expect(secondMarkErr).NotTo(HaveOccurred())
 
-					headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, recheckCheckCount)
+					headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, 3)
 					Expect(err).NotTo(HaveOccurred())
 
 					headerBlockNumbers := getBlockNumbers(headers)
@@ -336,11 +338,13 @@ var _ = Describe("Checked Headers repository", func() {
 					Expect(headerBlockNumbers).NotTo(ContainElement(excludedHeader.BlockNumber))
 				})
 
-				It("includes header with block number > 45 back from latest with check count of 1", func() {
+				It("includes header with block number > 45 back from latest with check count of 2", func() {
 					err := repo.MarkHeaderChecked(secondHeaderID)
 					Expect(err).NotTo(HaveOccurred())
+					secondCheckErr := repo.MarkHeaderChecked(secondHeaderID)
+					Expect(secondCheckErr).NotTo(HaveOccurred())
 
-					headers, err := repo.UncheckedHeaders(firstBlock, -1, recheckCheckCount)
+					headers, err := repo.UncheckedHeaders(firstBlock, -1, 3)
 					Expect(err).NotTo(HaveOccurred())
 
 					headerBlockNumbers := getBlockNumbers(headers)

--- a/pkg/datastore/postgres/repositories/checked_headers_repository_test.go
+++ b/pkg/datastore/postgres/repositories/checked_headers_repository_test.go
@@ -30,6 +30,339 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("Checked Headers repository", func() {
+	var (
+		db               = test_config.NewTestDB(test_config.NewTestNode())
+		repo             datastore.CheckedHeadersRepository
+		pluginSchemaName = "plugin"
+	)
+
+	Describe("without a valid setup", func() {
+		BeforeEach(func() {
+			test_config.CleanTestDB(db)
+		})
+
+		It("errors for a schema that isn't present", func() {
+			var err error
+			repo, err = repositories.NewCheckedHeadersRepository(db, pluginSchemaName)
+			Expect(err.Error()).To(ContainSubstring("invalid schema"))
+			Expect(repo).To(BeNil())
+		})
+	})
+
+	Describe("with a valid database schema", func() {
+
+		BeforeEach(func() {
+			test_config.CleanTestDB(db)
+			Expect(createPluginCheckedHeadersTable(db, pluginSchemaName)).To(Succeed())
+
+			var repoErr error
+			repo, repoErr = repositories.NewCheckedHeadersRepository(db, pluginSchemaName)
+			Expect(repoErr).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(clearPluginSchema(db, pluginSchemaName)).To(Succeed())
+		})
+
+		Describe("MarkHeaderChecked", func() {
+			It("marks passed header as checked on insert", func() {
+				headerRepository := repositories.NewHeaderRepository(db)
+				headerID, headerErr := headerRepository.CreateOrUpdateHeader(fakes.FakeHeader)
+				Expect(headerErr).NotTo(HaveOccurred())
+
+				Expect(repo.MarkHeaderChecked(headerID)).To(Succeed())
+
+				Expect(selectCheckedHeaders(db, pluginSchemaName, headerID)).To(Equal(1))
+			})
+
+			It("increments check count on update", func() {
+				headerRepository := repositories.NewHeaderRepository(db)
+				headerID, headerErr := headerRepository.CreateOrUpdateHeader(fakes.FakeHeader)
+				Expect(headerErr).NotTo(HaveOccurred())
+
+				Expect(repo.MarkHeaderChecked(headerID)).To(Succeed())
+				Expect(repo.MarkHeaderChecked(headerID)).To(Succeed())
+
+				Expect(selectCheckedHeaders(db, pluginSchemaName, headerID)).To(Equal(2))
+			})
+		})
+
+		Describe("MarkSingleHeaderUnchecked", func() {
+			It("marks headers with matching block number as unchecked", func() {
+				blockNumber := rand.Int63()
+				fakeHeader := fakes.GetFakeHeader(blockNumber)
+				headerRepository := repositories.NewHeaderRepository(db)
+				headerID, insertHeaderErr := headerRepository.CreateOrUpdateHeader(fakeHeader)
+				Expect(insertHeaderErr).NotTo(HaveOccurred())
+				Expect(repo.MarkHeaderChecked(headerID)).To(Succeed())
+
+				Expect(repo.MarkSingleHeaderUnchecked(blockNumber)).To(Succeed())
+
+				Expect(selectCheckedHeaders(db, pluginSchemaName, headerID)).To(BeZero())
+			})
+
+			It("leaves headers without a matching block number alone", func() {
+				checkedBlockNumber := rand.Int63()
+				uncheckedBlockNumber := checkedBlockNumber + 1
+				checkedHeader := fakes.GetFakeHeader(checkedBlockNumber)
+				uncheckedHeader := fakes.GetFakeHeader(uncheckedBlockNumber)
+				headerRepository := repositories.NewHeaderRepository(db)
+				checkedHeaderID, insertCheckedHeaderErr := headerRepository.CreateOrUpdateHeader(checkedHeader)
+				Expect(insertCheckedHeaderErr).NotTo(HaveOccurred())
+				uncheckedHeaderID, insertUncheckedHeaderErr := headerRepository.CreateOrUpdateHeader(uncheckedHeader)
+				Expect(insertUncheckedHeaderErr).NotTo(HaveOccurred())
+
+				// mark both headers as checked
+				Expect(repo.MarkHeaderChecked(checkedHeaderID)).To(Succeed())
+				Expect(repo.MarkHeaderChecked(uncheckedHeaderID)).To(Succeed())
+
+				// re-mark unchecked header as unchecked
+				Expect(repo.MarkSingleHeaderUnchecked(uncheckedBlockNumber)).To(Succeed())
+
+				// Verify the other block was not checked (1 checked header)
+				Expect(selectCheckedHeaders(db, pluginSchemaName, checkedHeaderID)).To(Equal(1))
+			})
+		})
+
+		Describe("UncheckedHeaders", func() {
+			var (
+				headerRepository datastore.HeaderRepository
+				firstBlock,
+				secondBlock,
+				thirdBlock,
+				lastBlock,
+				secondHeaderID,
+				thirdHeaderID int64
+				blockNumbers        []int64
+				headerIDs           []int64
+				err                 error
+				uncheckedCheckCount = int64(1)
+				recheckCheckCount   = int64(2)
+			)
+
+			BeforeEach(func() {
+				headerRepository = repositories.NewHeaderRepository(db)
+
+				lastBlock = rand.Int63()
+				thirdBlock = lastBlock - 15
+				secondBlock = lastBlock - (15 + 30)
+				firstBlock = lastBlock - (15 + 30 + 45)
+
+				blockNumbers = []int64{firstBlock, secondBlock, thirdBlock, lastBlock}
+
+				headerIDs = []int64{}
+				for _, n := range blockNumbers {
+					headerID, err := headerRepository.CreateOrUpdateHeader(fakes.GetFakeHeader(n))
+					Expect(err).NotTo(HaveOccurred())
+					headerIDs = append(headerIDs, headerID)
+				}
+				secondHeaderID = headerIDs[1]
+				thirdHeaderID = headerIDs[2]
+			})
+
+			Describe("when ending block is specified", func() {
+				It("excludes headers that are out of range", func() {
+					headers, err := repo.UncheckedHeaders(firstBlock, thirdBlock, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+
+					headerBlockNumbers := getBlockNumbers(headers)
+					Expect(headerBlockNumbers).To(ConsistOf(firstBlock, secondBlock, thirdBlock))
+					Expect(headerBlockNumbers).NotTo(ContainElement(lastBlock))
+				})
+
+				It("excludes headers that have been checked more than the check count", func() {
+					Expect(repo.MarkHeaderChecked(secondHeaderID)).To(Succeed())
+
+					headers, err := repo.UncheckedHeaders(firstBlock, thirdBlock, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+
+					headerBlockNumbers := getBlockNumbers(headers)
+					Expect(headerBlockNumbers).To(ConsistOf(firstBlock, thirdBlock))
+					Expect(headerBlockNumbers).NotTo(ContainElement(secondBlock))
+				})
+
+				Describe("when header has already been checked", func() {
+					It("includes header with block number >= 15 back from latest with check count of 1", func() {
+						Expect(repo.MarkHeaderChecked(thirdHeaderID)).To(Succeed())
+
+						headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, recheckCheckCount)
+						Expect(err).NotTo(HaveOccurred())
+
+						headerBlockNumbers := getBlockNumbers(headers)
+						Expect(headerBlockNumbers).To(ContainElement(thirdBlock))
+					})
+
+					It("excludes header with block number < 15 back from latest with check count of 1", func() {
+						excludedHeader := fakes.GetFakeHeader(thirdBlock + 1)
+						excludedHeaderID, createHeaderErr := headerRepository.CreateOrUpdateHeader(excludedHeader)
+						Expect(createHeaderErr).NotTo(HaveOccurred())
+						Expect(repo.MarkHeaderChecked(excludedHeaderID)).To(Succeed())
+
+						headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, recheckCheckCount)
+						Expect(err).NotTo(HaveOccurred())
+
+						headerBlockNumbers := getBlockNumbers(headers)
+						Expect(headerBlockNumbers).NotTo(ContainElement(excludedHeader.BlockNumber))
+					})
+
+					It("includes header with block number > 45 back from latest with check count of 2", func() {
+						Expect(repo.MarkHeaderChecked(secondHeaderID)).To(Succeed())
+						Expect(repo.MarkHeaderChecked(secondHeaderID)).To(Succeed())
+
+						headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, 3)
+						Expect(err).NotTo(HaveOccurred())
+
+						headerBlockNumbers := getBlockNumbers(headers)
+						Expect(headerBlockNumbers).To(ContainElement(secondBlock))
+					})
+
+					It("excludes header with block number < 45 back from latest with check count of 2", func() {
+						excludedHeader := fakes.GetFakeHeader(secondBlock + 1)
+						excludedHeaderID, createHeaderErr := headerRepository.CreateOrUpdateHeader(excludedHeader)
+						Expect(createHeaderErr).NotTo(HaveOccurred())
+
+						Expect(repo.MarkHeaderChecked(excludedHeaderID)).To(Succeed())
+						Expect(repo.MarkHeaderChecked(excludedHeaderID)).To(Succeed())
+
+						headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, 3)
+						Expect(err).NotTo(HaveOccurred())
+
+						headerBlockNumbers := getBlockNumbers(headers)
+						Expect(headerBlockNumbers).NotTo(ContainElement(excludedHeader.BlockNumber))
+					})
+				})
+
+				It("only returns headers associated with any node", func() {
+					dbTwo := test_config.NewTestDB(core.Node{ID: "second"})
+					headerRepositoryTwo := repositories.NewHeaderRepository(dbTwo)
+					repoTwo, repoErr := repositories.NewCheckedHeadersRepository(dbTwo, pluginSchemaName)
+					Expect(repoErr).NotTo(HaveOccurred())
+
+					for _, n := range blockNumbers {
+						_, err = headerRepositoryTwo.CreateOrUpdateHeader(fakes.GetFakeHeader(n + 10))
+						Expect(err).NotTo(HaveOccurred())
+					}
+					allHeaders := []int64{firstBlock, firstBlock + 10, secondBlock, secondBlock + 10, thirdBlock, thirdBlock + 10}
+
+					nodeOneMissingHeaders, err := repo.UncheckedHeaders(firstBlock, thirdBlock+10, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+					nodeOneHeaderBlockNumbers := getBlockNumbers(nodeOneMissingHeaders)
+					Expect(nodeOneHeaderBlockNumbers).To(ConsistOf(allHeaders))
+
+					nodeTwoMissingHeaders, err := repoTwo.UncheckedHeaders(firstBlock, thirdBlock+10, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+					nodeTwoHeaderBlockNumbers := getBlockNumbers(nodeTwoMissingHeaders)
+					Expect(nodeTwoHeaderBlockNumbers).To(ConsistOf(allHeaders))
+				})
+			})
+
+			Describe("when ending block is -1", func() {
+				It("includes all non-checked headers when ending block is -1 ", func() {
+					headers, err := repo.UncheckedHeaders(firstBlock, -1, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+
+					headerBlockNumbers := getBlockNumbers(headers)
+					Expect(headerBlockNumbers).To(ConsistOf(firstBlock, secondBlock, thirdBlock, lastBlock))
+				})
+
+				It("excludes headers that have been checked more than the check count", func() {
+					Expect(repo.MarkHeaderChecked(headerIDs[1])).To(Succeed())
+
+					headers, err := repo.UncheckedHeaders(firstBlock, -1, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+
+					headerBlockNumbers := getBlockNumbers(headers)
+					Expect(headerBlockNumbers).To(ConsistOf(firstBlock, thirdBlock, lastBlock))
+					Expect(headerBlockNumbers).NotTo(ContainElement(secondBlock))
+				})
+
+				Describe("when header has already been checked", func() {
+					It("includes header with block number > 15 back from latest with check count of 1", func() {
+						Expect(repo.MarkHeaderChecked(thirdHeaderID)).To(Succeed())
+
+						headers, err := repo.UncheckedHeaders(firstBlock, -1, recheckCheckCount)
+						Expect(err).NotTo(HaveOccurred())
+
+						headerBlockNumbers := getBlockNumbers(headers)
+						Expect(headerBlockNumbers).To(ContainElement(thirdBlock))
+					})
+
+					It("excludes header with block number < 15 back from latest with check count of 1", func() {
+						excludedHeader := fakes.GetFakeHeader(thirdBlock + 1)
+						excludedHeaderID, createHeaderErr := headerRepository.CreateOrUpdateHeader(excludedHeader)
+						Expect(createHeaderErr).NotTo(HaveOccurred())
+						Expect(repo.MarkHeaderChecked(excludedHeaderID)).To(Succeed())
+
+						headers, err := repo.UncheckedHeaders(firstBlock, -1, recheckCheckCount)
+						Expect(err).NotTo(HaveOccurred())
+
+						headerBlockNumbers := getBlockNumbers(headers)
+						Expect(headerBlockNumbers).NotTo(ContainElement(excludedHeader.BlockNumber))
+					})
+
+					It("includes header with block number > 45 back from latest with check count of 2", func() {
+						Expect(repo.MarkHeaderChecked(secondHeaderID)).To(Succeed())
+						Expect(repo.MarkHeaderChecked(secondHeaderID)).To(Succeed())
+
+						headers, err := repo.UncheckedHeaders(firstBlock, -1, 3)
+						Expect(err).NotTo(HaveOccurred())
+
+						headerBlockNumbers := getBlockNumbers(headers)
+						Expect(headerBlockNumbers).To(ContainElement(secondBlock))
+					})
+
+					It("excludes header with block number < 45 back from latest with check count of 2", func() {
+						excludedHeader := fakes.GetFakeHeader(secondBlock + 1)
+						excludedHeaderID, createHeaderErr := headerRepository.CreateOrUpdateHeader(excludedHeader)
+						Expect(createHeaderErr).NotTo(HaveOccurred())
+
+						Expect(repo.MarkHeaderChecked(excludedHeaderID)).To(Succeed())
+						Expect(repo.MarkHeaderChecked(excludedHeaderID)).To(Succeed())
+
+						headers, err := repo.UncheckedHeaders(firstBlock, -1, 3)
+						Expect(err).NotTo(HaveOccurred())
+
+						headerBlockNumbers := getBlockNumbers(headers)
+						Expect(headerBlockNumbers).NotTo(ContainElement(excludedHeader.BlockNumber))
+					})
+				})
+
+				It("returns headers associated with any node", func() {
+					dbTwo := test_config.NewTestDB(core.Node{ID: "second"})
+					headerRepositoryTwo := repositories.NewHeaderRepository(dbTwo)
+					repoTwo, repoErr := repositories.NewCheckedHeadersRepository(dbTwo, pluginSchemaName)
+					Expect(repoErr).NotTo(HaveOccurred())
+
+					for _, n := range blockNumbers {
+						_, err = headerRepositoryTwo.CreateOrUpdateHeader(fakes.GetFakeHeader(n + 10))
+						Expect(err).NotTo(HaveOccurred())
+					}
+					allHeaders := []int64{firstBlock, firstBlock + 10, secondBlock, secondBlock + 10, thirdBlock, thirdBlock + 10, lastBlock, lastBlock + 10}
+
+					nodeOneMissingHeaders, err := repo.UncheckedHeaders(firstBlock, -1, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+					nodeOneBlockNumbers := getBlockNumbers(nodeOneMissingHeaders)
+					Expect(nodeOneBlockNumbers).To(ConsistOf(allHeaders))
+
+					nodeTwoMissingHeaders, err := repoTwo.UncheckedHeaders(firstBlock, -1, uncheckedCheckCount)
+					Expect(err).NotTo(HaveOccurred())
+					nodeTwoBlockNumbers := getBlockNumbers(nodeTwoMissingHeaders)
+					Expect(nodeTwoBlockNumbers).To(ConsistOf(allHeaders))
+				})
+			})
+		})
+	})
+})
+
+func getBlockNumbers(headers []core.Header) []int64 {
+	var headerBlockNumbers []int64
+	for _, header := range headers {
+		headerBlockNumbers = append(headerBlockNumbers, header.BlockNumber)
+	}
+	return headerBlockNumbers
+}
+
 func selectCheckedHeaders(db *postgres.DB, schemaName string, headerID int64) (int, error) {
 	var checkedCount int
 	queryString := fmt.Sprintf(`SELECT check_count FROM %s.checked_headers WHERE header_id = $1`, schemaName)
@@ -38,6 +371,15 @@ func selectCheckedHeaders(db *postgres.DB, schemaName string, headerID int64) (i
 }
 
 func createPluginSchema(db *postgres.DB, schemaName string) error {
+	prepareSchema := `
+CREATE SCHEMA IF NOT EXISTS %[1]s;
+`
+
+	_, schemaError := db.Exec(fmt.Sprintf(prepareSchema, schemaName))
+	return schemaError
+}
+
+func createPluginCheckedHeadersTable(db *postgres.DB, schemaName string) error {
 	prepareSchema := `
 CREATE SCHEMA IF NOT EXISTS %[1]s;
 
@@ -55,348 +397,4 @@ CREATE TABLE %[1]s.checked_headers (
 func clearPluginSchema(db *postgres.DB, schemaName string) error {
 	_, err := db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", schemaName))
 	return err
-}
-
-var _ = Describe("Checked Headers repository", func() {
-	var (
-		db               = test_config.NewTestDB(test_config.NewTestNode())
-		repo             datastore.CheckedHeadersRepository
-		pluginSchemaName = "plugin"
-	)
-
-	BeforeEach(func() {
-		test_config.CleanTestDB(db)
-		schemaErr := createPluginSchema(db, pluginSchemaName)
-		Expect(schemaErr).NotTo(HaveOccurred())
-
-		repo = repositories.NewCheckedHeadersRepository(db, pluginSchemaName)
-	})
-
-	AfterEach(func() {
-		err := clearPluginSchema(db, pluginSchemaName)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	Describe("MarkHeaderChecked", func() {
-		It("marks passed header as checked on insert", func() {
-			headerRepository := repositories.NewHeaderRepository(db)
-			headerID, headerErr := headerRepository.CreateOrUpdateHeader(fakes.FakeHeader)
-			Expect(headerErr).NotTo(HaveOccurred())
-
-			err := repo.MarkHeaderChecked(headerID)
-
-			Expect(err).NotTo(HaveOccurred())
-			checkedCount, fetchErr := selectCheckedHeaders(db, pluginSchemaName, headerID)
-			Expect(fetchErr).NotTo(HaveOccurred())
-			Expect(checkedCount).To(Equal(1))
-		})
-
-		It("increments check count on update", func() {
-			headerRepository := repositories.NewHeaderRepository(db)
-			headerID, headerErr := headerRepository.CreateOrUpdateHeader(fakes.FakeHeader)
-			Expect(headerErr).NotTo(HaveOccurred())
-
-			insertErr := repo.MarkHeaderChecked(headerID)
-			Expect(insertErr).NotTo(HaveOccurred())
-
-			updateErr := repo.MarkHeaderChecked(headerID)
-			Expect(updateErr).NotTo(HaveOccurred())
-
-			checkedCount, fetchErr := selectCheckedHeaders(db, pluginSchemaName, headerID)
-			Expect(fetchErr).NotTo(HaveOccurred())
-			Expect(checkedCount).To(Equal(2))
-		})
-	})
-
-	Describe("MarkSingleHeaderUnchecked", func() {
-		It("marks headers with matching block number as unchecked", func() {
-			blockNumber := rand.Int63()
-			fakeHeader := fakes.GetFakeHeader(blockNumber)
-			headerRepository := repositories.NewHeaderRepository(db)
-			headerID, insertHeaderErr := headerRepository.CreateOrUpdateHeader(fakeHeader)
-			Expect(insertHeaderErr).NotTo(HaveOccurred())
-			markHeaderCheckedErr := repo.MarkHeaderChecked(headerID)
-			Expect(markHeaderCheckedErr).NotTo(HaveOccurred())
-
-			err := repo.MarkSingleHeaderUnchecked(blockNumber)
-			Expect(err).NotTo(HaveOccurred())
-
-			headerCheckCount, getHeaderErr := selectCheckedHeaders(db, pluginSchemaName, headerID)
-			Expect(getHeaderErr).NotTo(HaveOccurred())
-			Expect(headerCheckCount).To(BeZero())
-		})
-
-		It("leaves headers without a matching block number alone", func() {
-			checkedBlockNumber := rand.Int63()
-			uncheckedBlockNumber := checkedBlockNumber + 1
-			checkedHeader := fakes.GetFakeHeader(checkedBlockNumber)
-			uncheckedHeader := fakes.GetFakeHeader(uncheckedBlockNumber)
-			headerRepository := repositories.NewHeaderRepository(db)
-			checkedHeaderID, insertCheckedHeaderErr := headerRepository.CreateOrUpdateHeader(checkedHeader)
-			Expect(insertCheckedHeaderErr).NotTo(HaveOccurred())
-			uncheckedHeaderID, insertUncheckedHeaderErr := headerRepository.CreateOrUpdateHeader(uncheckedHeader)
-			Expect(insertUncheckedHeaderErr).NotTo(HaveOccurred())
-
-			// mark both headers as checked
-			markCheckedHeaderErr := repo.MarkHeaderChecked(checkedHeaderID)
-			Expect(markCheckedHeaderErr).NotTo(HaveOccurred())
-			markUncheckedHeaderErr := repo.MarkHeaderChecked(uncheckedHeaderID)
-			Expect(markUncheckedHeaderErr).NotTo(HaveOccurred())
-
-			// re-mark unchecked header as unchecked
-			err := repo.MarkSingleHeaderUnchecked(uncheckedBlockNumber)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Verify the other block was ignored
-			checkedHeaderCount, checkedHeaderErr := selectCheckedHeaders(db, pluginSchemaName, checkedHeaderID)
-			Expect(checkedHeaderErr).NotTo(HaveOccurred())
-			Expect(checkedHeaderCount).To(Equal(1))
-		})
-	})
-
-	Describe("UncheckedHeaders", func() {
-		var (
-			headerRepository datastore.HeaderRepository
-			firstBlock,
-			secondBlock,
-			thirdBlock,
-			lastBlock,
-			secondHeaderID,
-			thirdHeaderID int64
-			blockNumbers        []int64
-			headerIDs           []int64
-			err                 error
-			uncheckedCheckCount = int64(1)
-			recheckCheckCount   = int64(2)
-		)
-
-		BeforeEach(func() {
-			headerRepository = repositories.NewHeaderRepository(db)
-
-			lastBlock = rand.Int63()
-			thirdBlock = lastBlock - 15
-			secondBlock = lastBlock - (15 + 30)
-			firstBlock = lastBlock - (15 + 30 + 45)
-
-			blockNumbers = []int64{firstBlock, secondBlock, thirdBlock, lastBlock}
-
-			headerIDs = []int64{}
-			for _, n := range blockNumbers {
-				headerID, err := headerRepository.CreateOrUpdateHeader(fakes.GetFakeHeader(n))
-				headerIDs = append(headerIDs, headerID)
-				Expect(err).NotTo(HaveOccurred())
-			}
-			secondHeaderID = headerIDs[1]
-			thirdHeaderID = headerIDs[2]
-		})
-
-		Describe("when ending block is specified", func() {
-			It("excludes headers that are out of range", func() {
-				headers, err := repo.UncheckedHeaders(firstBlock, thirdBlock, uncheckedCheckCount)
-				Expect(err).NotTo(HaveOccurred())
-
-				headerBlockNumbers := getBlockNumbers(headers)
-				Expect(headerBlockNumbers).To(ConsistOf(firstBlock, secondBlock, thirdBlock))
-				Expect(headerBlockNumbers).NotTo(ContainElement(lastBlock))
-			})
-
-			It("excludes headers that have been checked more than the check count", func() {
-				err = repo.MarkHeaderChecked(secondHeaderID)
-				Expect(err).NotTo(HaveOccurred())
-
-				headers, err := repo.UncheckedHeaders(firstBlock, thirdBlock, uncheckedCheckCount)
-				Expect(err).NotTo(HaveOccurred())
-
-				headerBlockNumbers := getBlockNumbers(headers)
-				Expect(headerBlockNumbers).To(ConsistOf(firstBlock, thirdBlock))
-				Expect(headerBlockNumbers).NotTo(ContainElement(secondBlock))
-			})
-
-			Describe("when header has already been checked", func() {
-				It("includes header with block number >= 15 back from latest with check count of 1", func() {
-					err := repo.MarkHeaderChecked(thirdHeaderID)
-					Expect(err).NotTo(HaveOccurred())
-
-					headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, recheckCheckCount)
-					Expect(err).NotTo(HaveOccurred())
-
-					headerBlockNumbers := getBlockNumbers(headers)
-					Expect(headerBlockNumbers).To(ContainElement(thirdBlock))
-				})
-
-				It("excludes header with block number < 15 back from latest with check count of 1", func() {
-					excludedHeader := fakes.GetFakeHeader(thirdBlock + 1)
-					excludedHeaderID, createHeaderErr := headerRepository.CreateOrUpdateHeader(excludedHeader)
-					Expect(createHeaderErr).NotTo(HaveOccurred())
-					updateHeaderErr := repo.MarkHeaderChecked(excludedHeaderID)
-					Expect(updateHeaderErr).NotTo(HaveOccurred())
-
-					headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, recheckCheckCount)
-					Expect(err).NotTo(HaveOccurred())
-
-					headerBlockNumbers := getBlockNumbers(headers)
-					Expect(headerBlockNumbers).NotTo(ContainElement(excludedHeader.BlockNumber))
-				})
-
-				It("includes header with block number > 45 back from latest with check count of 2", func() {
-					err := repo.MarkHeaderChecked(secondHeaderID)
-					Expect(err).NotTo(HaveOccurred())
-					secondMarkErr := repo.MarkHeaderChecked(secondHeaderID)
-					Expect(secondMarkErr).NotTo(HaveOccurred())
-
-					headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, 3)
-					Expect(err).NotTo(HaveOccurred())
-
-					headerBlockNumbers := getBlockNumbers(headers)
-					Expect(headerBlockNumbers).To(ContainElement(secondBlock))
-				})
-
-				It("excludes header with block number < 45 back from latest with check count of 2", func() {
-					excludedHeader := fakes.GetFakeHeader(secondBlock + 1)
-					excludedHeaderID, createHeaderErr := headerRepository.CreateOrUpdateHeader(excludedHeader)
-					Expect(createHeaderErr).NotTo(HaveOccurred())
-
-					firstCheckErr := repo.MarkHeaderChecked(excludedHeaderID)
-					Expect(firstCheckErr).NotTo(HaveOccurred())
-					secondCheckErr := repo.MarkHeaderChecked(excludedHeaderID)
-					Expect(secondCheckErr).NotTo(HaveOccurred())
-
-					headers, err := repo.UncheckedHeaders(firstBlock, lastBlock, 3)
-					Expect(err).NotTo(HaveOccurred())
-
-					headerBlockNumbers := getBlockNumbers(headers)
-					Expect(headerBlockNumbers).NotTo(ContainElement(excludedHeader.BlockNumber))
-				})
-			})
-
-			It("only returns headers associated with any node", func() {
-				dbTwo := test_config.NewTestDB(core.Node{ID: "second"})
-				headerRepositoryTwo := repositories.NewHeaderRepository(dbTwo)
-				repoTwo := repositories.NewCheckedHeadersRepository(dbTwo, pluginSchemaName)
-				for _, n := range blockNumbers {
-					_, err = headerRepositoryTwo.CreateOrUpdateHeader(fakes.GetFakeHeader(n + 10))
-					Expect(err).NotTo(HaveOccurred())
-				}
-				allHeaders := []int64{firstBlock, firstBlock + 10, secondBlock, secondBlock + 10, thirdBlock, thirdBlock + 10}
-
-				nodeOneMissingHeaders, err := repo.UncheckedHeaders(firstBlock, thirdBlock+10, uncheckedCheckCount)
-				Expect(err).NotTo(HaveOccurred())
-				nodeOneHeaderBlockNumbers := getBlockNumbers(nodeOneMissingHeaders)
-				Expect(nodeOneHeaderBlockNumbers).To(ConsistOf(allHeaders))
-
-				nodeTwoMissingHeaders, err := repoTwo.UncheckedHeaders(firstBlock, thirdBlock+10, uncheckedCheckCount)
-				Expect(err).NotTo(HaveOccurred())
-				nodeTwoHeaderBlockNumbers := getBlockNumbers(nodeTwoMissingHeaders)
-				Expect(nodeTwoHeaderBlockNumbers).To(ConsistOf(allHeaders))
-			})
-		})
-
-		Describe("when ending block is -1", func() {
-			It("includes all non-checked headers when ending block is -1 ", func() {
-				headers, err := repo.UncheckedHeaders(firstBlock, -1, uncheckedCheckCount)
-				Expect(err).NotTo(HaveOccurred())
-
-				headerBlockNumbers := getBlockNumbers(headers)
-				Expect(headerBlockNumbers).To(ConsistOf(firstBlock, secondBlock, thirdBlock, lastBlock))
-			})
-
-			It("excludes headers that have been checked more than the check count", func() {
-				err := repo.MarkHeaderChecked(headerIDs[1])
-				Expect(err).NotTo(HaveOccurred())
-
-				headers, err := repo.UncheckedHeaders(firstBlock, -1, uncheckedCheckCount)
-				Expect(err).NotTo(HaveOccurred())
-
-				headerBlockNumbers := getBlockNumbers(headers)
-				Expect(headerBlockNumbers).To(ConsistOf(firstBlock, thirdBlock, lastBlock))
-				Expect(headerBlockNumbers).NotTo(ContainElement(secondBlock))
-			})
-
-			Describe("when header has already been checked", func() {
-				It("includes header with block number > 15 back from latest with check count of 1", func() {
-					err := repo.MarkHeaderChecked(thirdHeaderID)
-					Expect(err).NotTo(HaveOccurred())
-
-					headers, err := repo.UncheckedHeaders(firstBlock, -1, recheckCheckCount)
-					Expect(err).NotTo(HaveOccurred())
-
-					headerBlockNumbers := getBlockNumbers(headers)
-					Expect(headerBlockNumbers).To(ContainElement(thirdBlock))
-				})
-
-				It("excludes header with block number < 15 back from latest with check count of 1", func() {
-					excludedHeader := fakes.GetFakeHeader(thirdBlock + 1)
-					excludedHeaderID, createHeaderErr := headerRepository.CreateOrUpdateHeader(excludedHeader)
-					Expect(createHeaderErr).NotTo(HaveOccurred())
-					updateHeaderErr := repo.MarkHeaderChecked(excludedHeaderID)
-					Expect(updateHeaderErr).NotTo(HaveOccurred())
-
-					headers, err := repo.UncheckedHeaders(firstBlock, -1, recheckCheckCount)
-					Expect(err).NotTo(HaveOccurred())
-
-					headerBlockNumbers := getBlockNumbers(headers)
-					Expect(headerBlockNumbers).NotTo(ContainElement(excludedHeader.BlockNumber))
-				})
-
-				It("includes header with block number > 45 back from latest with check count of 2", func() {
-					err := repo.MarkHeaderChecked(secondHeaderID)
-					Expect(err).NotTo(HaveOccurred())
-					secondCheckErr := repo.MarkHeaderChecked(secondHeaderID)
-					Expect(secondCheckErr).NotTo(HaveOccurred())
-
-					headers, err := repo.UncheckedHeaders(firstBlock, -1, 3)
-					Expect(err).NotTo(HaveOccurred())
-
-					headerBlockNumbers := getBlockNumbers(headers)
-					Expect(headerBlockNumbers).To(ContainElement(secondBlock))
-				})
-
-				It("excludes header with block number < 45 back from latest with check count of 2", func() {
-					excludedHeader := fakes.GetFakeHeader(secondBlock + 1)
-					excludedHeaderID, createHeaderErr := headerRepository.CreateOrUpdateHeader(excludedHeader)
-					Expect(createHeaderErr).NotTo(HaveOccurred())
-
-					updateHeaderErr := repo.MarkHeaderChecked(excludedHeaderID)
-					Expect(updateHeaderErr).NotTo(HaveOccurred())
-					updateHeaderErr = repo.MarkHeaderChecked(excludedHeaderID)
-					Expect(updateHeaderErr).NotTo(HaveOccurred())
-
-					headers, err := repo.UncheckedHeaders(firstBlock, -1, 3)
-					Expect(err).NotTo(HaveOccurred())
-
-					headerBlockNumbers := getBlockNumbers(headers)
-					Expect(headerBlockNumbers).NotTo(ContainElement(excludedHeader.BlockNumber))
-				})
-			})
-
-			It("returns headers associated with any node", func() {
-				dbTwo := test_config.NewTestDB(core.Node{ID: "second"})
-				headerRepositoryTwo := repositories.NewHeaderRepository(dbTwo)
-				repoTwo := repositories.NewCheckedHeadersRepository(dbTwo, pluginSchemaName)
-				for _, n := range blockNumbers {
-					_, err = headerRepositoryTwo.CreateOrUpdateHeader(fakes.GetFakeHeader(n + 10))
-					Expect(err).NotTo(HaveOccurred())
-				}
-				allHeaders := []int64{firstBlock, firstBlock + 10, secondBlock, secondBlock + 10, thirdBlock, thirdBlock + 10, lastBlock, lastBlock + 10}
-
-				nodeOneMissingHeaders, err := repo.UncheckedHeaders(firstBlock, -1, uncheckedCheckCount)
-				Expect(err).NotTo(HaveOccurred())
-				nodeOneBlockNumbers := getBlockNumbers(nodeOneMissingHeaders)
-				Expect(nodeOneBlockNumbers).To(ConsistOf(allHeaders))
-
-				nodeTwoMissingHeaders, err := repoTwo.UncheckedHeaders(firstBlock, -1, uncheckedCheckCount)
-				Expect(err).NotTo(HaveOccurred())
-				nodeTwoBlockNumbers := getBlockNumbers(nodeTwoMissingHeaders)
-				Expect(nodeTwoBlockNumbers).To(ConsistOf(allHeaders))
-			})
-		})
-	})
-})
-
-func getBlockNumbers(headers []core.Header) []int64 {
-	var headerBlockNumbers []int64
-	for _, header := range headers {
-		headerBlockNumbers = append(headerBlockNumbers, header.BlockNumber)
-	}
-	return headerBlockNumbers
 }

--- a/test_config/test_config.go
+++ b/test_config/test_config.go
@@ -17,7 +17,6 @@
 package test_config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -31,7 +30,6 @@ import (
 
 var TestConfig *viper.Viper
 var DBConfig config.Database
-var TestClient config.Client
 var ABIFilePath string
 
 func init() {
@@ -47,16 +45,6 @@ func setTestConfig() {
 	if err != nil {
 		logrus.Fatal(err)
 	}
-	ipc := TestConfig.GetString("client.ipcPath")
-
-	// If we don't have an ipc path in the config file, check the env variable
-	if ipc == "" {
-		TestConfig.BindEnv("url", "CLIENT_IPCPATH")
-		ipc = TestConfig.GetString("url")
-	}
-	if ipc == "" {
-		logrus.Fatal(errors.New("testing.toml IPC path or $CLIENT_IPCPATH env variable need to be set"))
-	}
 
 	hn := TestConfig.GetString("database.hostname")
 	port := TestConfig.GetInt("database.port")
@@ -66,9 +54,6 @@ func setTestConfig() {
 		Hostname: hn,
 		Name:     name,
 		Port:     port,
-	}
-	TestClient = config.Client{
-		IPCPath: ipc,
 	}
 }
 


### PR DESCRIPTION
As part of pulling Oasis into its own repository (and by extension removing it from MCD-transformers) we can't share the same "check_count" on the headers table anymore. Plugins provide their schema and must have a matching table.

This also removes the need for CLIENT_IPCPATH from the make test command, which was an accident.