### PR TITLE
Vdb 1237 viper flag updates

### DIFF
--- a/cmd/backfillEvents.go
+++ b/cmd/backfillEvents.go
@@ -15,8 +15,8 @@ var endingBlockNumber int64
 // backfillEventsCmd represents the backfillEvents command
 var backfillEventsCmd = &cobra.Command{
 	Use:   "backfillEvents",
-	Short: "BackFill events from already-checked headers",
-	Long: `Fetch and persist events from configured transformers across a range
+	Short: "Backfill events from already-checked headers",
+	Long: `Run this command to fetch and persist events from configured transformers across a range
 of headers that may have already been checked for logs. Useful when adding a
 new event transformer to an instance that has already been running and marking
 headers checked as it queried for the previous (now incomplete) set of logs.`,

--- a/cmd/backfillEvents.go
+++ b/cmd/backfillEvents.go
@@ -10,7 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var endingBlockNumber int64
+var (
+	endingBlockNumber         int64
+	endingBlockNumberFlagName = "ending-block-number"
+)
 
 // backfillEventsCmd represents the backfillEvents command
 var backfillEventsCmd = &cobra.Command{
@@ -33,8 +36,8 @@ headers checked as it queried for the previous (now incomplete) set of logs.`,
 
 func init() {
 	rootCmd.AddCommand(backfillEventsCmd)
-	backfillEventsCmd.Flags().Int64VarP(&endingBlockNumber, "ending-block-number", "e", -1, "last block from which to back-fill events")
-	backfillEventsCmd.MarkFlagRequired("ending-block-number")
+	backfillEventsCmd.Flags().Int64VarP(&endingBlockNumber, endingBlockNumberFlagName, "e", -1, "last block from which to back-fill events")
+	backfillEventsCmd.MarkFlagRequired(endingBlockNumberFlagName)
 }
 
 func backFillEvents() error {

--- a/cmd/backfillStorage.go
+++ b/cmd/backfillStorage.go
@@ -12,30 +12,37 @@ import (
 )
 
 var (
-	backfillStorageAddress          string
-	backfillStorageAddressFlag      = "backfill-storage-contract-address"
-	backfillStorageEndBlockFlag     = "backfill-storage-end-block"
-	backfillStorageEndBlockNumber   int64
-	backfillStorageStartBlockFlag   = "backfill-storage-start-block"
-	backfillStorageStartBlockNumber int64
+	backfillStorageAddress             string
+	backfillStorageAddressFlag         = "backfill-storage-contract-address"
+	backfillStorageEndBlockFlag        = "backfill-storage-end-block"
+	backfillStorageEndBlockNumber      int64
+	backfillStorageStartBlockFlag      = "backfill-storage-start-block"
+	backfillStorageStartBlockNumber    int64
+	backfillStorageContractAddressFlag = "backfill-storage-contract-address"
 )
 
 // backfillStorageCmd represents the backfillStorage command
 var backfillStorageCmd = &cobra.Command{
 	Use:   "backfillStorage",
 	Short: "Backfill smart contract storage for a range of blocks",
-	Long: `Run this command to fetch and persist contract storage for a range of blocks. Useful
-if you have started watching diffs from a new contract but do not have storage data from before
-you started running the transformer.
-Requires a config file structured the same as it would be for running compose or execute (to specify which
-addresses and storage slots must be back-filled).
-Requires CLI flags are backfill-storage-start-block (-s) and backfill-storage-end-block (-e) to define range of blocks
-that need to be back-filled.
-Optional CLI flag is backfill-storage-contract-address (-a) to specify a single contract address that needs to be
-back-filled (if not necessary for all transformers).
-Before running this command, verify that you have run headerSync and execute for the desired blocks. Headers are
-required for generating queries for storage slots by hash, and execute is required since the identifier for storage
-slots that represent mappings and dynamic arrays depend on data derived from events.`,
+	Long: fmt.Sprintf(`Run this command to fetch and persist contract storage for a range of blocks. Useful
+if you have started watching diffs from a new contract but do not have storage data
+from before you started running the transformer.
+
+   -Requires a config file structured the same as it would be for running compose or 
+    execute (to specify which addresses and storage slots must be back-filled).
+
+   -Required CLI flags are %s (-s) and 
+    %s (-e) to define range of block that need to be back-filled.
+
+   -Optional CLI flag is %s (-a) to specify a single 
+    contract address that needs to be back-filled (if not necessary for all transformers).
+
+Before running this command, verify that you have run headerSync and execute for the 
+desired blocks. Headers are required for generating queries for storage slots by hash,
+and execute is required since the identifier for storage slots that represent mappings
+and dynamic arrays depend on data derived from events.`, backfillStorageStartBlockFlag,
+		backfillStorageEndBlockFlag, backfillStorageContractAddressFlag),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SubCommand = cmd.CalledAs()
 		LogWithCommand = *logrus.WithField("SubCommand", SubCommand)

--- a/cmd/backfillStorage.go
+++ b/cmd/backfillStorage.go
@@ -24,9 +24,10 @@ var (
 var backfillStorageCmd = &cobra.Command{
 	Use:   "backfillStorage",
 	Short: "Backfill smart contract storage for a range of blocks",
-	Long: `Fetch and persist contract storage for a range of blocks. Useful if you have started watching diffs from a
-new contract but do not have storage data from before you started running the transformer.
-Requires a config file structured the same as it would be for running compose or composeAndExecute (to specify which
+	Long: `Run this command to fetch and persist contract storage for a range of blocks. Useful
+if you have started watching diffs from a new contract but do not have storage data from before
+you started running the transformer.
+Requires a config file structured the same as it would be for running compose or execute (to specify which
 addresses and storage slots must be back-filled).
 Requires CLI flags are backfill-storage-start-block (-s) and backfill-storage-end-block (-e) to define range of blocks
 that need to be back-filled.

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -26,74 +26,11 @@ import (
 var composeCmd = &cobra.Command{
 	Use:   "compose",
 	Short: "Composes transformer initializer plugin",
-	Long: `This command needs a config .toml file of form:
+	Long: `Run this command in order to write and build a go plugin with a list
+of transformers specified in the config file. The plugin is loaded and the set
+of transformer initializers can be executed over by the appropriate watcher.
 
-[database]
-    name     = "vulcanize_public"
-    hostname = "localhost"
-    user     = "vulcanize"
-    password = "vulcanize"
-    port     = 5432
-
-[client]
-    ipcPath  = "/Users/user/Library/Ethereum/geth.ipc"
-
-[exporter]
-    home     = "github.com/makerdao/vulcanizedb"
-    name     = "exampleTransformerExporter"
-    schema   = "<plugin schema>"
-    save     = false
-    transformerNames = [
-        "transformer1",
-        "transformer2",
-        "transformer3",
-        "transformer4",
-    ]
-    [exporter.transformer1]
-        path = "path/to/transformer1"
-        type = "eth_event"
-        repository = "github.com/account/repo"
-        migrations = "db/migrations"
-        rank = "0"
-    [exporter.transformer2]
-        path = "path/to/transformer2"
-        type = "eth_contract"
-        repository = "github.com/account/repo"
-        migrations = "db/migrations"
-        rank = "0"
-    [exporter.transformer3]
-        path = "path/to/transformer3"
-        type = "eth_event"
-        repository = "github.com/account/repo"
-        migrations = "db/migrations"
-        rank = "0"
-    [exporter.transformer4]
-        path = "path/to/transformer4"
-        type = "eth_storage"
-        repository = "github.com/account2/repo2"
-        migrations = "to/db/migrations"
-        rank = "1"
-
-
-Note: If any of the plugin transformer need additional
-configuration variables include them in the .toml file as well
-
-This information is used to write and build a go plugin with a transformer 
-set composed from the transformer imports specified in the config file
-This plugin is loaded and the set of transformer initializers is exported
-from it and loaded into and executed over by the appropriate watcher. 
-
-The type of watcher that the transformer works with is specified using the 
-type variable for each transformer in the config. Currently there are watchers 
-of event data from an eth node (eth_event) and storage data from an eth node 
-(eth_storage), and a more generic interface for accepting contract_watcher pkg
-based transformers which can perform event watching provided only a contract
-address (eth_contract).
-
-Transformers of different types can be ran together in the same command using a 
-single config file or in separate command instances using different config files
-
-Specify config location when executing the command:
+This command needs a config file location specified:
 ./vulcanizedb compose --config=./environments/config_name.toml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		SubCommand = cmd.CalledAs()

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -37,11 +37,11 @@ import (
 var executeCmd = &cobra.Command{
 	Use:   "execute",
 	Short: "Executes a precomposed transformer initializer plugin",
-	Long: `Run this command to take the composed plugin and pass it to the
-appropriate watcher to execute over. The plugin file needs to be located in the
-/plugins directory and this command assumes the db migrations remain from when
-the plugin was composed. Additionally, the plugin must have been composed by the
-same version of vulcanizedb or else it will not be compatible.
+	Long: `Run this command to take the composed plugin and pass it to the appropriate watcher 
+to execute over. The plugin file needs to be located in the /plugins directory 
+and this command assumes the db migrations remain from when the plugin was composed.
+Additionally, the plugin must have been composed by the same version of vulcanizedb 
+or else it will not be compatible.
 
 This command needs a config file location specified: 
 ./vulcanizedb execute --config=./environments/config_name.toml`,

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -36,31 +36,14 @@ import (
 // executeCmd represents the execute command
 var executeCmd = &cobra.Command{
 	Use:   "execute",
-	Short: "executes a precomposed transformer initializer plugin",
-	Long: `This command needs a config .toml file of form:
+	Short: "Executes a precomposed transformer initializer plugin",
+	Long: `Run this command to take the composed plugin and pass it to the
+appropriate watcher to execute over. The plugin file needs to be located in the
+/plugins directory and this command assumes the db migrations remain from when
+the plugin was composed. Additionally, the plugin must have been composed by the
+same version of vulcanizedb or else it will not be compatible.
 
-[database]
-    name     = "vulcanize_public"
-    hostname = "localhost"
-    user     = "vulcanize"
-    password = "vulcanize"
-    port     = 5432
-
-[client]
-    ipcPath  = "/Users/user/Library/Ethereum/geth.ipc"
-
-[exporter]
-    name     = "exampleTransformerExporter"
-
-Note: If any of the plugin transformer need additional
-configuration variables include them in the .toml file as well
-
-The exporter.name is the name (without extension) of the plugin to be loaded.
-The plugin file needs to be located in the /plugins directory and this command assumes 
-the db migrations remain from when the plugin was composed. Additionally, the plugin 
-must have been composed by the same version of vulcanizedb or else it will not be compatible.
-
-Specify config location when executing the command:
+This command needs a config file location specified: 
 ./vulcanizedb execute --config=./environments/config_name.toml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		SubCommand = cmd.CalledAs()

--- a/cmd/extractDiffs.go
+++ b/cmd/extractDiffs.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/ethereum/go-ethereum"
@@ -17,17 +18,18 @@ import (
 )
 
 var (
-	storageDiffsPath   string
-	storageDiffsSource string
+	storageDiffsPathFlag   = "fileSystem-storageDiffsPath"
+	storageDiffsPath       string
+	storageDiffsSourceFlag = "storageDiffs-source"
+	storageDiffsSource     string
 )
 
 // extractDiffsCmd represents the extractDiffs command
 var extractDiffsCmd = &cobra.Command{
 	Use:   "extractDiffs",
 	Short: "Extract storage diffs from a node and write them to postgres",
-	Long: `Run this command to reads storage diffs from either a CSV or JSON RPC subscription.
-	Configure which with the STORAGEDIFFS_SOURCE flag. Received diffs are
-written to public.storage_diff.`,
+	Long: fmt.Sprintf(`Run this command to reads storage diffs from either a CSV or JSON RPC subscription.
+Configure which with the %s flag. Received diffs are written to public.storage_diff.`, storageDiffsSourceFlag),
 	Run: func(cmd *cobra.Command, args []string) {
 		SubCommand = cmd.CalledAs()
 		LogWithCommand = *logrus.WithField("SubCommand", SubCommand)
@@ -37,8 +39,8 @@ written to public.storage_diff.`,
 
 func init() {
 	rootCmd.AddCommand(extractDiffsCmd)
-	extractDiffsCmd.Flags().StringVarP(&storageDiffsSource, "storageDiffs-source", "s", "csv", "where to get the state diffs: csv or geth")
-	extractDiffsCmd.Flags().StringVarP(&storageDiffsPath, "fileSystem-storageDiffsPath", "p", "", "location of storage diffs csv file")
+	extractDiffsCmd.Flags().StringVarP(&storageDiffsSource, storageDiffsSourceFlag, "s", "csv", "where to get the state diffs: csv or geth")
+	extractDiffsCmd.Flags().StringVarP(&storageDiffsPath, storageDiffsPathFlag, "p", "", "location of storage diffs csv file")
 }
 
 func getContractAddresses() []string {

--- a/cmd/extractDiffs.go
+++ b/cmd/extractDiffs.go
@@ -16,6 +16,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+var (
+	storageDiffsPath   string
+	storageDiffsSource string
+)
+
 // extractDiffsCmd represents the extractDiffs command
 var extractDiffsCmd = &cobra.Command{
 	Use:   "extractDiffs",
@@ -32,6 +37,8 @@ written to public.storage_diff.`,
 
 func init() {
 	rootCmd.AddCommand(extractDiffsCmd)
+	extractDiffsCmd.Flags().StringVarP(&storageDiffsSource, "storageDiffs-source", "s", "csv", "where to get the state diffs: csv or geth")
+	extractDiffsCmd.Flags().StringVarP(&storageDiffsPath, "fileSystem-storageDiffsPath", "p", "", "location of storage diffs csv file")
 }
 
 func getContractAddresses() []string {

--- a/cmd/extractDiffs.go
+++ b/cmd/extractDiffs.go
@@ -20,9 +20,9 @@ import (
 var extractDiffsCmd = &cobra.Command{
 	Use:   "extractDiffs",
 	Short: "Extract storage diffs from a node and write them to postgres",
-	Long: `Reads storage diffs from either a CSV or JSON RPC subscription.
+	Long: `Run this command to reads storage diffs from either a CSV or JSON RPC subscription.
 	Configure which with the STORAGEDIFFS_SOURCE flag. Received diffs are
-	written to public.storage_diff.`,
+written to public.storage_diff.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		SubCommand = cmd.CalledAs()
 		LogWithCommand = *logrus.WithField("SubCommand", SubCommand)

--- a/cmd/headerSync.go
+++ b/cmd/headerSync.go
@@ -30,15 +30,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var startingBlockFlagName = "starting-block-number"
+
 // headerSyncCmd represents the headerSync command
 var headerSyncCmd = &cobra.Command{
 	Use:   "headerSync",
 	Short: "Syncs VulcanizeDB with local ethereum node's block headers",
-	Long: `Run this command to sync VulcanizeDB with an ethereum node. Populates
-Postgres with block headers.
+	Long: `Run this command to sync VulcanizeDB with an ethereum node. It populates
+Postgres with block headers. You may point to a config file, specify settings via 
+CLI flags, or it will attempt to run with default values.`,
 
-This command needs a config file location specified:
-./vulcanizedb headerSync --starting-block-number 0 --config public.toml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		SubCommand = cmd.CalledAs()
 		LogWithCommand = *logrus.WithField("SubCommand", SubCommand)
@@ -48,7 +49,7 @@ This command needs a config file location specified:
 
 func init() {
 	rootCmd.AddCommand(headerSyncCmd)
-	headerSyncCmd.Flags().Int64VarP(&startingBlockNumber, "starting-block-number", "s", 0, "Block number to start syncing from")
+	headerSyncCmd.Flags().Int64VarP(&startingBlockNumber, startingBlockFlagName, "s", 0, "Block number to start syncing from")
 }
 
 func backFillAllHeaders(blockchain core.BlockChain, headerRepository datastore.HeaderRepository, missingBlocksPopulated chan int, startingBlockNumber int64) {
@@ -104,7 +105,7 @@ func validateHeaderSyncArgs(blockChain *eth.BlockChain) {
 	}
 	lastBlockNumber := lastBlock.Int64()
 	if startingBlockNumber > lastBlockNumber {
-		LogWithCommand.Fatalf("starting block number (%d) greater than client's most recent synced block (%d)",
-			startingBlockNumber, lastBlockNumber)
+		LogWithCommand.Fatalf("--%s (%d) greater than client's most recent synced block (%d)",
+			startingBlockFlagName, startingBlockNumber, lastBlockNumber)
 	}
 }

--- a/cmd/headerSync.go
+++ b/cmd/headerSync.go
@@ -34,21 +34,11 @@ import (
 var headerSyncCmd = &cobra.Command{
 	Use:   "headerSync",
 	Short: "Syncs VulcanizeDB with local ethereum node's block headers",
-	Long: `Syncs VulcanizeDB with local ethereum node. Populates
+	Long: `Run this command to sync VulcanizeDB with an ethereum node. Populates
 Postgres with block headers.
 
-./vulcanizedb headerSync --starting-block-number 0 --config public.toml
-
-Expects ethereum node to be running and requires a .toml config:
-
-  [database]
-  name = "vulcanize_public"
-  hostname = "localhost"
-  port = 5432
-
-  [client]
-  ipcPath = "/Users/user/Library/Ethereum/geth.ipc"
-`,
+This command needs a config file location specified:
+./vulcanizedb headerSync --starting-block-number 0 --config public.toml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		SubCommand = cmd.CalledAs()
 		LogWithCommand = *logrus.WithField("SubCommand", SubCommand)

--- a/cmd/resetHeaderCheckCount.go
+++ b/cmd/resetHeaderCheckCount.go
@@ -34,7 +34,8 @@ var (
 var resetHeaderCheckCountCmd = &cobra.Command{
 	Use:   "resetHeaderCheckCount",
 	Short: "Resets header check_count for the given block number",
-	Long: fmt.Sprintf(`Resets check_count to zero for the given header so that the execute command may recheck that header's logs in case one was missed.
+	Long: fmt.Sprintf(`Run this command to reset the check_count to zero for a given header so that
+the execute command may recheck that header's logs in case one was missed.
 
 Use: ./vulcanizedb resetHeaderCheckCount --%s=<block number>`, resetHeaderFlagName),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,8 +52,6 @@ var (
 	recheckHeadersArg                    bool
 	retryInterval                        time.Duration
 	startingBlockNumber                  int64
-	storageDiffsPath                     string
-	storageDiffsSource                   string
 )
 
 const (
@@ -84,8 +82,6 @@ func initFuncs(cmd *cobra.Command, args []string) {
 
 func setViperConfigs() {
 	ipc = viper.GetString("client.ipcpath")
-	storageDiffsPath = viper.GetString("filesystem.storageDiffsPath")
-	storageDiffsSource = viper.GetString("storageDiffs.source")
 	databaseConfig = config.Database{
 		Name:     viper.GetString("database.name"),
 		Hostname: viper.GetString("database.hostname"),
@@ -122,8 +118,6 @@ func init() {
 	rootCmd.PersistentFlags().String("database-user", "", "database user")
 	rootCmd.PersistentFlags().String("database-password", "", "database password")
 	rootCmd.PersistentFlags().String("client-ipcPath", "", "location of geth.ipc file")
-	rootCmd.PersistentFlags().String("filesystem-storageDiffsPath", "", "location of storage diffs csv file")
-	rootCmd.PersistentFlags().String("storageDiffs-source", "csv", "where to get the state diffs: csv or geth")
 	rootCmd.PersistentFlags().String("exporter-name", "exporter", "name of exporter plugin")
 	rootCmd.PersistentFlags().String("log-level", logrus.InfoLevel.String(), "Log level (trace, debug, info, warn, error, fatal, panic")
 
@@ -133,8 +127,6 @@ func init() {
 	viper.BindPFlag("database.user", rootCmd.PersistentFlags().Lookup("database-user"))
 	viper.BindPFlag("database.password", rootCmd.PersistentFlags().Lookup("database-password"))
 	viper.BindPFlag("client.ipcPath", rootCmd.PersistentFlags().Lookup("client-ipcPath"))
-	viper.BindPFlag("filesystem.storageDiffsPath", rootCmd.PersistentFlags().Lookup("filesystem-storageDiffsPath"))
-	viper.BindPFlag("storageDiffs.source", rootCmd.PersistentFlags().Lookup("storageDiffs-source"))
 	viper.BindPFlag("exporter.fileName", rootCmd.PersistentFlags().Lookup("exporter-name"))
 	viper.BindPFlag("log.level", rootCmd.PersistentFlags().Lookup("log-level"))
 }


### PR DESCRIPTION
- This PR cleans up some documentation around the CLI commands

- There's an additional commit that reduces the scope of two global flags and moves them to `extractDiffs`. We may need to change the way we call it in our deployment.