### PR TITLE
Switch diff processing log from info to debug

### DIFF
--- a/libraries/shared/storage/fetcher/geth_rpc_storage_fetcher.go
+++ b/libraries/shared/storage/fetcher/geth_rpc_storage_fetcher.go
@@ -80,7 +80,7 @@ func (fetcher GethRpcStorageFetcher) handleDiffPayload(payload filters.Payload, 
 	}
 
 	for _, account := range stateDiff.UpdatedAccounts {
-		logrus.Infof(processingDiffsLogString, len(account.Storage), common.Bytes2Hex(account.Key))
+		logrus.Debugf(processingDiffsLogString, len(account.Storage), common.Bytes2Hex(account.Key))
 		for _, accountStorage := range account.Storage {
 			rawDiff, formatErr := types.FromGethStateDiff(account, &stateDiff, accountStorage)
 			if formatErr != nil {


### PR DESCRIPTION
- happens multiple times per block; reducing log level makes it easier
  to locate other info