### PR TITLE
Set workdir in runner for reset header Dockerfile

### DIFF
--- a/dockerfiles/reset_header_check_count/Dockerfile
+++ b/dockerfiles/reset_header_check_count/Dockerfile
@@ -6,6 +6,8 @@ RUN go build
 
 FROM makerdao/vdb-runner
 
+WORKDIR /app
+
 # Direct logs to stdout for docker log driver
 RUN ln -sf /dev/stdout /app/vulcanizedb.log
 


### PR DESCRIPTION
- required to create symbolic link for logs