### PR TITLE
(VDB-1732) Add script to delete header

### DIFF
--- a/cmd/deleteHeader.go
+++ b/cmd/deleteHeader.go
@@ -1,15 +1,16 @@
 package cmd
 
 import (
-	"errors"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/utils"
 	"github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
 )
 
-var deleteHeaderBlockNumber int64
+var (
+	blockNumberFlagName     string = "block-number"
+	deleteHeaderBlockNumber int64
+)
 
 // deleteHeaderCmd represents the deleteHeader command
 var deleteHeaderCmd = &cobra.Command{
@@ -29,14 +30,12 @@ in the header validation window (by default, within 15 of the head of the chain)
 }
 
 func init() {
-	deleteHeaderCmd.Flags().Int64VarP(&deleteHeaderBlockNumber, "block-number", "b", -1, "block number of the header to delete")
 	rootCmd.AddCommand(deleteHeaderCmd)
+	deleteHeaderCmd.Flags().Int64VarP(&deleteHeaderBlockNumber, blockNumberFlagName, "b", -1, "block number of the header to delete")
+	deleteHeaderCmd.MarkFlagRequired(blockNumberFlagName)
 }
 
 func deleteHeader() error {
-	if deleteHeaderBlockNumber == -1 {
-		return errors.New("must pass block number for header to delete")
-	}
 	blockChain := getBlockChain()
 	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
 	headerRepository := repositories.NewHeaderRepository(&db)

--- a/cmd/deleteHeader.go
+++ b/cmd/deleteHeader.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"errors"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
+	"github.com/makerdao/vulcanizedb/utils"
+	"github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+var deleteHeaderBlockNumber int64
+
+// deleteHeaderCmd represents the deleteHeader command
+var deleteHeaderCmd = &cobra.Command{
+	Use:   "deleteHeader",
+	Short: "Delete a header with a given block number from the headers table",
+	Long: `Useful if a non-canonical header exists in the DB at a block that's earlier than what's being scanned
+in the header validation window (by default, within 15 of the head of the chain).`,
+	Run: func(cmd *cobra.Command, args []string) {
+		SubCommand = cmd.CalledAs()
+		LogWithCommand = *logrus.WithField("SubCommand", SubCommand)
+		err := deleteHeader()
+		if err != nil {
+			LogWithCommand.Fatalf("failed to delete header: %s", err.Error())
+		}
+		LogWithCommand.Infof("successfully deleted header %d", deleteHeaderBlockNumber)
+	},
+}
+
+func init() {
+	deleteHeaderCmd.Flags().Int64VarP(&deleteHeaderBlockNumber, "block-number", "b", -1, "block number of the header to delete")
+	rootCmd.AddCommand(deleteHeaderCmd)
+}
+
+func deleteHeader() error {
+	if deleteHeaderBlockNumber == -1 {
+		return errors.New("must pass block number for header to delete")
+	}
+	blockChain := getBlockChain()
+	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
+	headerRepository := repositories.NewHeaderRepository(&db)
+	return headerRepository.DeleteHeader(deleteHeaderBlockNumber)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.15
 require (
 	github.com/dave/jennifer v1.3.0
 	github.com/ethereum/go-ethereum v1.9.22
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hpcloud/tail v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmoiron/sqlx v1.2.0

--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -236,5 +236,5 @@ func (watcher StorageWatcher) handleTransformError(transformErr error, diff type
 }
 
 func isCommonTransformError(err error) bool {
-	return errors.Is(err, sql.ErrNoRows) || errors.Is(err, types.ErrKeyNotFound)
+	return errors.Is(err, sql.ErrNoRows) || errors.Is(err, types.ErrKeyNotFound) || errors.Is(err, postgres.ErrHeaderDoesNotExist)
 }

--- a/libraries/shared/watcher/storage_watcher_test.go
+++ b/libraries/shared/watcher/storage_watcher_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/libraries/shared/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/watcher"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	"github.com/makerdao/vulcanizedb/test_config"
 	. "github.com/onsi/ginkgo"
@@ -191,7 +192,7 @@ func SharedExecuteBehavior(input *ExecuteInput) {
 			}
 			setDiffsToReturn(storageWatcher.DiffStatus, mockDiffsRepository, []types.PersistedDiff{diffWithoutHeader})
 			setGetDiffsErrors(storageWatcher.DiffStatus, mockDiffsRepository, []error{nil, fakes.FakeError})
-			mockHeaderRepository.GetHeaderByBlockNumberError = sql.ErrNoRows
+			mockHeaderRepository.GetHeaderByBlockNumberError = postgres.ErrHeaderDoesNotExist
 
 			err := storageWatcher.Execute()
 
@@ -200,7 +201,7 @@ func SharedExecuteBehavior(input *ExecuteInput) {
 			Expect(mockDiffsRepository.MarkTransformedPassedID).NotTo(Equal(diffWithoutHeader.ID))
 		})
 
-		It("does not return sql.ErrNoRows if header for diff not found", func() {
+		It("does not return postgres.ErrHeaderDoesNotExist if header for diff not found", func() {
 			diffWithoutHeader := types.PersistedDiff{
 				RawDiff: types.RawDiff{
 					Address:     contractAddress,
@@ -211,7 +212,7 @@ func SharedExecuteBehavior(input *ExecuteInput) {
 			}
 			setDiffsToReturn(storageWatcher.DiffStatus, mockDiffsRepository, []types.PersistedDiff{diffWithoutHeader})
 			setGetDiffsErrors(storageWatcher.DiffStatus, mockDiffsRepository, []error{nil, fakes.FakeError})
-			mockHeaderRepository.GetHeaderByBlockNumberError = sql.ErrNoRows
+			mockHeaderRepository.GetHeaderByBlockNumberError = postgres.ErrHeaderDoesNotExist
 
 			err := storageWatcher.Execute()
 

--- a/pkg/datastore/postgres/errors.go
+++ b/pkg/datastore/postgres/errors.go
@@ -10,6 +10,8 @@ const (
 	SettingNodeFailedMsg  = "unable to set db node"
 )
 
+var ErrHeaderDoesNotExist = errors.New("header does not exist")
+
 func ErrDBConnectionFailed(connectErr error) error {
 	return formatError(DbConnectionFailedMsg, connectErr.Error())
 }

--- a/pkg/datastore/postgres/repositories/header_repository.go
+++ b/pkg/datastore/postgres/repositories/header_repository.go
@@ -94,6 +94,9 @@ func (repo headerRepository) GetHeaderByBlockNumber(blockNumber int64) (core.Hea
 	var header core.Header
 	err := repo.db.Get(&header,
 		`SELECT id, block_number, hash, raw, block_timestamp FROM headers WHERE block_number = $1`, blockNumber)
+	if err == sql.ErrNoRows {
+		return header, postgres.ErrHeaderDoesNotExist
+	}
 	return header, err
 }
 

--- a/pkg/datastore/postgres/repositories/header_repository_test.go
+++ b/pkg/datastore/postgres/repositories/header_repository_test.go
@@ -294,7 +294,7 @@ var _ = Describe("Block header repository", func() {
 			persistedHeader, getErr := repo.GetHeaderByBlockNumber(blockNumber)
 			Expect(persistedHeader).To(BeZero())
 			Expect(getErr).To(HaveOccurred())
-			Expect(getErr).To(MatchError(sql.ErrNoRows))
+			Expect(getErr).To(MatchError(postgres.ErrHeaderDoesNotExist))
 		})
 	})
 

--- a/pkg/datastore/postgres/repositories/header_repository_test.go
+++ b/pkg/datastore/postgres/repositories/header_repository_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	"github.com/makerdao/vulcanizedb/test_config"
@@ -270,6 +271,30 @@ var _ = Describe("Block header repository", func() {
 				FROM public.transactions WHERE header_id = $1`, headerID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(dbTransactions)).To(Equal(1))
+		})
+	})
+
+	Describe("deleting a header", func() {
+		It("returns error if header does not exist", func() {
+			err := repo.DeleteHeader(rand.Int63())
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(postgres.ErrHeaderDoesNotExist))
+		})
+
+		It("deletes header if it exists", func() {
+			blockNumber := rand.Int63()
+			header := fakes.GetFakeHeader(blockNumber)
+			_, insertErr := repo.CreateOrUpdateHeader(header)
+			Expect(insertErr).NotTo(HaveOccurred())
+
+			err := repo.DeleteHeader(blockNumber)
+
+			Expect(err).NotTo(HaveOccurred())
+			persistedHeader, getErr := repo.GetHeaderByBlockNumber(blockNumber)
+			Expect(persistedHeader).To(BeZero())
+			Expect(getErr).To(HaveOccurred())
+			Expect(getErr).To(MatchError(sql.ErrNoRows))
 		})
 	})
 

--- a/pkg/datastore/repository.go
+++ b/pkg/datastore/repository.go
@@ -41,6 +41,7 @@ type HeaderRepository interface {
 	CreateOrUpdateHeader(header core.Header) (int64, error)
 	CreateTransactions(headerID int64, transactions []core.TransactionModel) error
 	CreateTransactionInTx(tx *sqlx.Tx, headerID int64, transaction core.TransactionModel) (int64, error)
+	DeleteHeader(blockNumber int64) error
 	GetHeaderByBlockNumber(blockNumber int64) (core.Header, error)
 	GetHeaderByID(id int64) (core.Header, error)
 	GetHeadersInRange(startingBlock, endingBlock int64) ([]core.Header, error)

--- a/pkg/fakes/mock_header_repository.go
+++ b/pkg/fakes/mock_header_repository.go
@@ -78,6 +78,10 @@ func (mock *MockHeaderRepository) CreateTransactionInTx(tx *sqlx.Tx, headerID in
 	panic("implement me")
 }
 
+func (mock *MockHeaderRepository) DeleteHeader(blockNumber int64) error {
+	panic("implement me")
+}
+
 func (mock *MockHeaderRepository) GetHeaderByBlockNumber(blockNumber int64) (core.Header, error) {
 	mock.GetHeaderPassedBlockNumber = blockNumber
 	return core.Header{


### PR DESCRIPTION
- To remove headers that enter the DB and survive past the validation
  window in headerSync (which would otherwise clear out non-canonical
  headers).
- Takes a block number and only executes a delete if a header with
  that block number exists in the DB.