### PR TITLE
Add pending diff status migration

### DIFF
--- a/db/migrations/00012_add_pending_diff_status.sql
+++ b/db/migrations/00012_add_pending_diff_status.sql
@@ -1,0 +1,32 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+ALTER TYPE public.diff_status ADD VALUE 'pending' AFTER 'new';
+
+CREATE INDEX CONCURRENTLY storage_diff_pending_status_index
+    ON public.storage_diff (status) WHERE status = 'pending';
+
+-- +goose Down
+UPDATE public.storage_diff SET status = 'new' WHERE status = 'pending';
+DROP INDEX storage_diff_new_status_index;
+DROP INDEX storage_diff_unrecognized_status_index;
+DROP INDEX storage_diff_pending_status_index;
+
+ALTER TABLE public.storage_diff ALTER COLUMN status DROP DEFAULT;
+ALTER TABLE public.storage_diff ALTER COLUMN status TYPE VARCHAR(255);
+
+DROP TYPE public.diff_status;
+CREATE TYPE public.diff_status AS ENUM (
+    'new',
+    'transformed',
+    'unrecognized',
+    'noncanonical',
+    'unwatched'
+    );
+
+ALTER TABLE public.storage_diff ALTER COLUMN status TYPE public.diff_status USING (status::diff_status);
+ALTER TABLE public.storage_diff ALTER COLUMN status SET DEFAULT 'new';
+
+CREATE INDEX CONCURRENTLY storage_diff_new_status_index
+    ON public.storage_diff (status) WHERE status = 'new';
+CREATE INDEX CONCURRENTLY storage_diff_unrecognized_status_index
+    ON public.storage_diff (status) WHERE status = 'unrecognized';

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -36,6 +36,7 @@ COMMENT ON SCHEMA public IS 'standard public schema';
 
 CREATE TYPE public.diff_status AS ENUM (
     'new',
+    'pending',
     'transformed',
     'unrecognized',
     'noncanonical',
@@ -847,6 +848,13 @@ CREATE INDEX storage_diff_eth_node ON public.storage_diff USING btree (eth_node_
 --
 
 CREATE INDEX storage_diff_new_status_index ON public.storage_diff USING btree (status) WHERE (status = 'new'::public.diff_status);
+
+
+--
+-- Name: storage_diff_pending_status_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX storage_diff_pending_status_index ON public.storage_diff USING btree (status) WHERE (status = 'pending'::public.diff_status);
 
 
 --


### PR DESCRIPTION
Alter the type in place - use No transaction. The rollback can't do that, because postgres doesn't allow removing an enum from a type.