### PR TITLE
(VDB-1743) Script to reset non-canonical diffs

### DIFF
--- a/cmd/deleteHeader.go
+++ b/cmd/deleteHeader.go
@@ -7,10 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	blockNumberFlagName     string = "block-number"
-	deleteHeaderBlockNumber int64
-)
+var deleteHeaderBlockNumber int64
 
 // deleteHeaderCmd represents the deleteHeader command
 var deleteHeaderCmd = &cobra.Command{

--- a/cmd/resetNonCanonicalDiffsToNew.go
+++ b/cmd/resetNonCanonicalDiffsToNew.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/makerdao/vulcanizedb/libraries/shared/storage"
+	"github.com/makerdao/vulcanizedb/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var resetDiffsBlockNumber int64
+
+// resetNonCanonicalDiffsToNewCmd represents the resetNonCanonicalDiffsToNew command
+var resetNonCanonicalDiffsToNewCmd = &cobra.Command{
+	Use:   "resetNonCanonicalDiffsToNew",
+	Short: "Reset diffs with status of 'non-canonical' at given block to 'new'.",
+	Long: `If the database has an invalid header at an older block (outside of the validation window),
+then diffs from the valid header will be marked as 'non-canonical'. In that case,
+we need to remove the invalid header and update the associated diffs' status so
+that they can be re-checked and transformed if valid. This command handles updating
+the diffs' status.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		SubCommand = cmd.CalledAs()
+		LogWithCommand = *logrus.WithField("SubCommand", SubCommand)
+		err := resetNonCanonicalDiffsToNew()
+		if err != nil {
+			LogWithCommand.Fatalf("failed to reset non-canonical diffs to new: %s", err.Error())
+		}
+		LogWithCommand.Infof("successfully reset non-canonical diffs to new at block %d", resetDiffsBlockNumber)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(resetNonCanonicalDiffsToNewCmd)
+	resetNonCanonicalDiffsToNewCmd.Flags().Int64VarP(&resetDiffsBlockNumber, blockNumberFlagName, "b", -1, "block number where non-canonical diffs should be marked new")
+	resetNonCanonicalDiffsToNewCmd.MarkFlagRequired(blockNumberFlagName)
+}
+
+func resetNonCanonicalDiffsToNew() error {
+	blockChain := getBlockChain()
+	db := utils.LoadPostgres(databaseConfig, blockChain.Node())
+	diffRepository := storage.NewDiffRepository(&db)
+	return diffRepository.MarkNoncanonicalDiffsAsNew(resetDiffsBlockNumber)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ import (
 var (
 	LogWithCommand                       logrus.Entry
 	SubCommand                           string
+	blockNumberFlagName                  = "block-number"
 	cfgFile                              string
 	databaseConfig                       config.Database
 	newDiffBlockFromHeadOfChain          int64

--- a/libraries/shared/mocks/storage_diff_repository.go
+++ b/libraries/shared/mocks/storage_diff_repository.go
@@ -96,6 +96,10 @@ func (repository *MockStorageDiffRepository) MarkNoncanonical(id int64) error {
 	return nil
 }
 
+func (repository *MockStorageDiffRepository) MarkNoncanonicalDiffsAsNew(blockNumber int64) error {
+	panic("implement me")
+}
+
 func (repository *MockStorageDiffRepository) MarkUnrecognized(id int64) error {
 	repository.MarkUnrecognizedPassedID = id
 	return nil

--- a/libraries/shared/storage/diff_repository.go
+++ b/libraries/shared/storage/diff_repository.go
@@ -31,6 +31,7 @@ type DiffRepository interface {
 	GetPendingDiffs(minID, limit int) ([]types.PersistedDiff, error)
 	MarkTransformed(id int64) error
 	MarkNoncanonical(id int64) error
+	MarkNoncanonicalDiffsAsNew(blockNumber int64) error
 	MarkUnrecognized(id int64) error
 	MarkUnwatched(id int64) error
 	MarkPending(id int64) error
@@ -127,6 +128,11 @@ func (repository diffRepository) MarkNoncanonical(id int64) error {
 		return fmt.Errorf("error marking diff %d checked: %w", id, err)
 	}
 	return nil
+}
+
+func (repository diffRepository) MarkNoncanonicalDiffsAsNew(blockNumber int64) error {
+	_, err := repository.db.Exec(`UPDATE public.storage_diff SET status = $1 WHERE block_height = $2 AND status = $3`, New, blockNumber, Noncanonical)
+	return err
 }
 
 func (repository diffRepository) MarkUnwatched(id int64) error {


### PR DESCRIPTION
- Enable re-scanning diffs inadvertantly marked non-canonical, which
  can happen if bad headers are inserted and then not removed by
  header validation (e.g. during a fork where the network advances
  more than 15 blocks before the node recovers).