### PR TITLE
(VDB-1786) Log event backfill current blocks

### DIFF
--- a/libraries/shared/logs/extractor.go
+++ b/libraries/shared/logs/extractor.go
@@ -164,6 +164,7 @@ func (extractor LogExtractor) BackFillLogs(endingBlock int64) error {
 	}
 
 	for _, r := range ranges {
+		logrus.Infof("backfilling events from blocks %d-%d", r[StartInterval], r[EndInterval])
 		headers, headersErr := extractor.HeaderRepository.GetHeadersInRange(r[StartInterval], r[EndInterval])
 		if headersErr != nil {
 			logrus.Errorf("error fetching missing headers: %s", headersErr)


### PR DESCRIPTION
- Emit what blocks are being scanned during event backfill to expose
  progress between start and end