### PR TITLE
VDB-1788: Return error when retrieving headers from bc fails in PopulateHeaders

### DIFF
--- a/pkg/fakes/mock_blockchain.go
+++ b/pkg/fakes/mock_blockchain.go
@@ -33,6 +33,7 @@ type MockBlockChain struct {
 	GetTransactionsError               error
 	GetTransactionsPassedHashes        []common.Hash
 	Transactions                       []core.TransactionModel
+	GetHeadersByNumbersErr             error
 	fetchContractDataErr               error
 	fetchContractDataPassedAbi         string
 	fetchContractDataPassedAddress     string
@@ -101,7 +102,7 @@ func (blockChain *MockBlockChain) GetHeadersByNumbers(blockNumbers []int64) ([]c
 		var header = core.Header{BlockNumber: blockNumber}
 		headers = append(headers, header)
 	}
-	return headers, nil
+	return headers, blockChain.GetHeadersByNumbersErr
 }
 
 func (blockChain *MockBlockChain) GetTransactions(transactionHashes []common.Hash) ([]core.TransactionModel, error) {

--- a/pkg/history/populate_headers.go
+++ b/pkg/history/populate_headers.go
@@ -47,11 +47,15 @@ func PopulateMissingHeaders(blockChain core.BlockChain, headerRepository datasto
 }
 
 func RetrieveAndUpdateHeaders(blockChain core.BlockChain, headerRepository datastore.HeaderRepository, blockNumbers []int64) (int, error) {
-	headers, err := blockChain.GetHeadersByNumbers(blockNumbers)
+	headers, getHeadersErr := blockChain.GetHeadersByNumbers(blockNumbers)
+	if getHeadersErr != nil {
+		return 0, getHeadersErr
+	}
+
 	for _, header := range headers {
-		_, err = headerRepository.CreateOrUpdateHeader(header)
-		if err != nil {
-			return 0, err
+		_, createOrUpdateHeaderErr := headerRepository.CreateOrUpdateHeader(header)
+		if createOrUpdateHeaderErr != nil {
+			return 0, createOrUpdateHeaderErr
 		}
 	}
 	return len(blockNumbers), nil

--- a/pkg/history/populate_headers_test.go
+++ b/pkg/history/populate_headers_test.go
@@ -102,4 +102,26 @@ var _ = Describe("Populating headers", func() {
 		Expect(err).To(MatchError(fakes.FakeError))
 		Expect(statusWriter.WriteCalled).To(BeFalse())
 	})
+
+	Describe("RetrieveAndUpdateHeaders", func() {
+		It("returns an error if getting headers from the blockchain fails", func(){
+			blockChain := fakes.NewMockBlockChain()
+			blockChain.GetHeadersByNumbersErr = fakes.FakeError
+
+			_, err := history.RetrieveAndUpdateHeaders(blockChain, headerRepository, []int64{})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fakes.FakeError))
+		})
+
+		It("returns an error when Creating or updating the header fails", func() {
+			blockChain := fakes.NewMockBlockChain()
+			headerRepository.SetCreateOrUpdateHeaderReturnErr(fakes.FakeError)
+			_, err := history.RetrieveAndUpdateHeaders(blockChain, headerRepository, []int64{startingBlock})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fakes.FakeError))
+		})
+	})
+
 })


### PR DESCRIPTION
I didn't make any changes to downgrade errors in headerSync, but did discover that we weren't returning an error right away from `RetrieveAndUpdateHeaders` if the call to the block chain to get `GetHeadersByNumbers` fails.