### PR TITLE
Change throttling log to debug

### DIFF
--- a/libraries/shared/watcher/storage_watcher.go
+++ b/libraries/shared/watcher/storage_watcher.go
@@ -122,7 +122,7 @@ func (watcher StorageWatcher) Execute() error {
 	}
 
 	for {
-		logrus.Infof("throttling to %v", watcher.minWaitTime)
+		logrus.Debugf("throttling to %v", watcher.minWaitTime)
 		err := watcher.Throttler(watcher.minWaitTime, watcher.transformDiffs)
 		if err != nil {
 			logrus.Errorf("error transforming diffs: %s", err.Error())


### PR DESCRIPTION
We're getting a lot of these logs, so I'm changing the log level from `info` to `debug`. Happy to rethink this change, if we feel like getting some info about throttling.
<img width="766" alt="Screen Shot 2021-01-27 at 3 09 13 PM" src="https://user-images.githubusercontent.com/4752801/106047521-b65da380-60b1-11eb-991e-6ef664985e17.png">
