### PR TITLE
Add types for clip

### DIFF
--- a/libraries/shared/storage/decoder.go
+++ b/libraries/shared/storage/decoder.go
@@ -40,6 +40,8 @@ func Decode(diff types.PersistedDiff, metadata types.ValueMetadata) interface{} 
 		return decodeInteger(diff.StorageValue.Bytes())
 	case types.Uint64:
 		return decodeInteger(diff.StorageValue.Bytes())
+	case types.Uint96:
+		return decodeInteger(diff.StorageValue.Bytes())
 	case types.Uint128:
 		return decodeInteger(diff.StorageValue.Bytes())
 	case types.Uint192:

--- a/libraries/shared/storage/decoder.go
+++ b/libraries/shared/storage/decoder.go
@@ -38,7 +38,11 @@ func Decode(diff types.PersistedDiff, metadata types.ValueMetadata) interface{} 
 		return decodeInteger(diff.StorageValue.Bytes())
 	case types.Uint48:
 		return decodeInteger(diff.StorageValue.Bytes())
+	case types.Uint64:
+		return decodeInteger(diff.StorageValue.Bytes())
 	case types.Uint128:
+		return decodeInteger(diff.StorageValue.Bytes())
+	case types.Uint192:
 		return decodeInteger(diff.StorageValue.Bytes())
 	case types.Address:
 		return decodeAddress(diff.StorageValue.Bytes())
@@ -98,7 +102,7 @@ func decodePackedSlot(raw []byte, packedTypes map[int]types.ValueType) (map[int]
 
 func decodeIndividualItem(itemBytes []byte, valueType types.ValueType) (string, error) {
 	switch valueType {
-	case types.Uint32, types.Uint48, types.Uint128:
+	case types.Uint32, types.Uint48, types.Uint64, types.Uint128, types.Uint192:
 		return decodeInteger(itemBytes), nil
 	case types.Address:
 		return decodeAddress(itemBytes), nil
@@ -113,8 +117,12 @@ func getNumberOfBytes(valueType types.ValueType) int {
 		return 32 / bitsPerByte
 	case types.Uint48:
 		return 48 / bitsPerByte
+	case types.Uint64:
+		return 64 / bitsPerByte
 	case types.Uint128:
 		return 128 / bitsPerByte
+	case types.Uint192:
+		return 192 / bitsPerByte
 	case types.Address:
 		return 20
 	default:

--- a/libraries/shared/storage/decoder_test.go
+++ b/libraries/shared/storage/decoder_test.go
@@ -214,5 +214,26 @@ var _ = Describe("Storage decoder", func() {
 			Expect(decodedValues[1]).To(Equal(big.NewInt(0).SetBytes(common.HexToHash("2a30").Bytes()).String()))
 			Expect(decodedValues[2]).To(Equal(big.NewInt(0).SetBytes(common.HexToHash("2a300").Bytes()).String()))
 		})
+
+		It("decodes a uint64 + uint192", func() {
+			packedStorageHex := "00000000348c771b1de11359f9ee9b8d0c93800000000000" +
+				"00038d7ea4c68000"
+			packedStorage := common.HexToHash(packedStorageHex)
+			diff := types.PersistedDiff{RawDiff: types.RawDiff{StorageValue: packedStorage}}
+			packedTypes := map[int]types.ValueType{}
+			packedTypes[0] = types.Uint64
+			packedTypes[1] = types.Uint192
+
+			metadata := types.ValueMetadata{
+				Type:        types.PackedSlot,
+				PackedTypes: packedTypes,
+			}
+
+			result := storage.Decode(diff, metadata)
+			decodedValues := result.(map[int]string)
+
+			Expect(decodedValues[0]).To(Equal(big.NewInt(0).SetBytes(common.HexToHash("38D7EA4C68000").Bytes()).String()))
+			Expect(decodedValues[1]).To(Equal(big.NewInt(0).SetBytes(common.HexToHash("348C771B1DE11359F9EE9B8D0C93800000000000").Bytes()).String()))
+		})
 	})
 })

--- a/libraries/shared/storage/decoder_test.go
+++ b/libraries/shared/storage/decoder_test.go
@@ -88,6 +88,16 @@ var _ = Describe("Storage decoder", func() {
 		Expect(result).To(Equal(big.NewInt(0).SetBytes(fakeInt.Bytes()).String()))
 	})
 
+	It("decodes uint96", func() {
+		fakeInt := common.HexToHash("0000000000000000000000000000000000000000000000000000000000000123")
+		diff := types.PersistedDiff{RawDiff: types.RawDiff{StorageValue: fakeInt}}
+		metadata := types.ValueMetadata{Type: types.Uint96}
+
+		result := storage.Decode(diff, metadata)
+
+		Expect(result).To(Equal(big.NewInt(0).SetBytes(fakeInt.Bytes()).String()))
+	})
+
 	It("decodes address", func() {
 		fakeAddress := common.HexToAddress("0x12345")
 		diff := types.PersistedDiff{RawDiff: types.RawDiff{StorageValue: fakeAddress.Hash()}}

--- a/libraries/shared/storage/types/value.go
+++ b/libraries/shared/storage/types/value.go
@@ -25,6 +25,8 @@ const (
 	Uint8
 	Uint32
 	Uint48
+	Uint64
+	Uint192
 	Uint128
 	Bytes32
 	Address

--- a/libraries/shared/storage/types/value.go
+++ b/libraries/shared/storage/types/value.go
@@ -26,6 +26,7 @@ const (
 	Uint32
 	Uint48
 	Uint64
+	Uint96
 	Uint192
 	Uint128
 	Bytes32

--- a/libraries/shared/storage/types/value_test.go
+++ b/libraries/shared/storage/types/value_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Storage value metadata getter", func() {
 		Expect(types.GetValueMetadata(metadataName, metadataKeys, metadataType)).To(Equal(expectedMetadata))
 	})
 
-	Describe("metadata for a packed storaged slot", func() {
+	Describe("metadata for a packed storage slot", func() {
 		It("returns metadata for multiple storage variables", func() {
 			metadataName := "fake_name"
 			metadataKeys := map[types.Key]string{"key": "value"}


### PR DESCRIPTION
The clip contract adds two new types `uint64` and `uint192` as packed storage values that need to be decoded by vulcanizedb. This change is necessary to support the new clip storage values.